### PR TITLE
Feature/bd lenght poc

### DIFF
--- a/src/main/kotlin/com/ing/serialization/bfl/serde/SerialDescriptorUtils.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/SerialDescriptorUtils.kt
@@ -28,4 +28,7 @@ val SerialDescriptor.simpleSerialName: String
     get() = serialName.split(".").last()
 
 val SerialKind.isTrulyPrimitive: Boolean
-    get() = this is PrimitiveKind && this !is PrimitiveKind.STRING
+    get() = this is PrimitiveKind
+        && this !is PrimitiveKind.STRING
+//        && this !is PrimitiveKind.DOUBLE
+//        && this !is PrimitiveKind.FLOAT

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/SerialDescriptorUtils.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/SerialDescriptorUtils.kt
@@ -28,7 +28,5 @@ val SerialDescriptor.simpleSerialName: String
     get() = serialName.split(".").last()
 
 val SerialKind.isTrulyPrimitive: Boolean
-    get() = this is PrimitiveKind
-        && this !is PrimitiveKind.STRING
-//        && this !is PrimitiveKind.DOUBLE
-//        && this !is PrimitiveKind.FLOAT
+    get() = this is PrimitiveKind &&
+        this !is PrimitiveKind.STRING

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
@@ -33,7 +33,7 @@ class PrimitiveElement(
             is PrimitiveKind.INT -> 4
             is PrimitiveKind.LONG -> 8
             is PrimitiveKind.CHAR -> 2
-            is PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> BigDecimalSurrogate.SIZE
+            is PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> BigDecimalSurrogate.DOUBLE_SIZE
             else -> error("Do not know how to compute layout for primitive $kind")
         }
 
@@ -95,12 +95,12 @@ class PrimitiveElement(
 
     private fun writeBigDecimal(output: DataOutput, surrogate: BigDecimalSurrogate?) {
         val serialization = surrogate?.let { inlinedSerialize(surrogate) }
-            ?: ByteArray(BigDecimalSurrogate.SIZE) { 0 }
+            ?: ByteArray(BigDecimalSurrogate.DOUBLE_SIZE) { 0 }
         output.write(serialization)
     }
 
     private fun readBigDecimal(input: DataInput): BigDecimal {
-        val surrogateInput = ByteArray(BigDecimalSurrogate.SIZE)
+        val surrogateInput = ByteArray(BigDecimalSurrogate.DOUBLE_SIZE)
         input.readFully(surrogateInput)
 
         val surrogate = deserialize<BigDecimalSurrogate>(surrogateInput)

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
@@ -34,7 +34,7 @@ class PrimitiveElement(
             is PrimitiveKind.INT -> 4
             is PrimitiveKind.LONG -> 8
             is PrimitiveKind.CHAR -> 2
-            is PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> BigDecimalSurrogate.DOUBLE_SIZE
+            is PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> DOUBLE_SIZE
             else -> error("Do not know how to compute layout for primitive $kind")
         }
 

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
@@ -3,7 +3,8 @@ package com.ing.serialization.bfl.serde.element
 import com.ing.serialization.bfl.api.reified.deserialize
 import com.ing.serialization.bfl.serde.SerdeError
 import com.ing.serialization.bfl.serde.isTrulyPrimitive
-import com.ing.serialization.bfl.serializers.BigDecimalSurrogate
+import com.ing.serialization.bfl.serializers.DoubleSurrogate
+import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_SIZE
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialKind
 import java.io.DataInput
@@ -51,11 +52,11 @@ class PrimitiveElement(
                 kind is PrimitiveKind.LONG && value is Long -> writeLong(value)
                 kind is PrimitiveKind.CHAR && value is Char -> writeChar(value.toInt())
                 kind is PrimitiveKind.FLOAT && value is Float -> {
-                    val surrogate = BigDecimalSurrogate.from(value)
+                    val surrogate = DoubleSurrogate.from(value)
                     writeBigDecimal(stream, surrogate)
                 }
                 kind is PrimitiveKind.DOUBLE && value is Double -> {
-                    val surrogate = BigDecimalSurrogate.from(value)
+                    val surrogate = DoubleSurrogate.from(value)
                     writeBigDecimal(stream, surrogate)
                 }
                 else -> error("$serialName cannot encode $value of type ${value::class.simpleName}")
@@ -93,17 +94,17 @@ class PrimitiveElement(
             } as? T ?: error("$serialName cannot decode required type")
         }
 
-    private fun writeBigDecimal(output: DataOutput, surrogate: BigDecimalSurrogate?) {
+    private fun writeBigDecimal(output: DataOutput, surrogate: DoubleSurrogate?) {
         val serialization = surrogate?.let { inlinedSerialize(surrogate) }
-            ?: ByteArray(BigDecimalSurrogate.DOUBLE_SIZE) { 0 }
+            ?: ByteArray(DOUBLE_SIZE) { 0 }
         output.write(serialization)
     }
 
     private fun readBigDecimal(input: DataInput): BigDecimal {
-        val surrogateInput = ByteArray(BigDecimalSurrogate.DOUBLE_SIZE)
+        val surrogateInput = ByteArray(DOUBLE_SIZE)
         input.readFully(surrogateInput)
 
-        val surrogate = deserialize<BigDecimalSurrogate>(surrogateInput)
+        val surrogate = deserialize<DoubleSurrogate>(surrogateInput)
 
         return surrogate.toOriginal()
     }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
@@ -1,15 +1,21 @@
 package com.ing.serialization.bfl.serde.element
 
+import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.api.reified.deserialize
 import com.ing.serialization.bfl.serde.SerdeError
 import com.ing.serialization.bfl.serde.isTrulyPrimitive
 import com.ing.serialization.bfl.serializers.DoubleSurrogate
 import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_SIZE
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialKind
 import java.io.DataInput
 import java.io.DataOutput
-import java.math.BigDecimal
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+import kotlin.reflect.KVisibility
+import kotlin.reflect.full.hasAnnotation
+import kotlin.reflect.full.memberProperties
 import com.ing.serialization.bfl.api.reified.serialize as inlinedSerialize
 
 /**
@@ -34,11 +40,29 @@ class PrimitiveElement(
             is PrimitiveKind.INT -> 4
             is PrimitiveKind.LONG -> 8
             is PrimitiveKind.CHAR -> 2
-            is PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> DOUBLE_SIZE
+            is PrimitiveKind.FLOAT -> TODO()
+//            is PrimitiveKind.DOUBLE -> DOUBLE_SIZE
+            is PrimitiveKind.DOUBLE -> serializedSizeOf(DoubleSurrogate::class)
             else -> error("Do not know how to compute layout for primitive $kind")
         }
 
         listOf(Pair("value", size))
+    }
+
+    private fun serializedSizeOf(kClass: KClass<*>): Int {
+        if (!kClass.hasAnnotation<Serializable>()) error("Can't determine serializable size of unserializable type. Please annotate with @Serializable.")
+
+        kClass.memberProperties.filter { it.visibility == KVisibility.PUBLIC }.sumBy { serializedSizeOf(it) }
+    }
+
+    private fun serializedSizeOf(kProperty1: KProperty1<out Any, *>): Int {
+        return if (!kProperty1.hasAnnotation<FixedLength>()) {
+
+        } else {
+
+        }
+
+
     }
 
     @Suppress("ComplexMethod")
@@ -51,17 +75,27 @@ class PrimitiveElement(
                 kind is PrimitiveKind.INT && value is Int -> writeInt(value)
                 kind is PrimitiveKind.LONG && value is Long -> writeLong(value)
                 kind is PrimitiveKind.CHAR && value is Char -> writeChar(value.toInt())
-                kind is PrimitiveKind.FLOAT && value is Float -> {
-                    val surrogate = DoubleSurrogate.from(value)
-                    writeBigDecimal(stream, surrogate)
-                }
-                kind is PrimitiveKind.DOUBLE && value is Double -> {
-                    val surrogate = DoubleSurrogate.from(value)
-                    writeBigDecimal(stream, surrogate)
-                }
+                kind is PrimitiveKind.FLOAT && value is Float -> TODO()
+                kind is PrimitiveKind.DOUBLE && value is Double -> writeDouble(stream, value)
                 else -> error("$serialName cannot encode $value of type ${value::class.simpleName}")
             }
         }
+    }
+
+    private fun writeFloat(stream: DataOutput, value: Float?) {
+        val serialization = when (value) {
+            is Float -> inlinedSerialize(FloatSurrogate.from(value))
+            else -> ByteArray(FLOAT_SIZE) { 0 }
+        }
+        stream.write(serialization)
+    }
+
+    private fun writeDouble(stream: DataOutput, value: Double?) {
+        val serialization = when (value) {
+            is Double -> inlinedSerialize(DoubleSurrogate.from(value))
+            else -> ByteArray(DOUBLE_SIZE) { 0 }
+        }
+        stream.write(serialization)
     }
 
     override fun encodeNull(output: DataOutput) =
@@ -73,8 +107,9 @@ class PrimitiveElement(
                 is PrimitiveKind.INT -> writeInt(0)
                 is PrimitiveKind.LONG -> writeLong(0)
                 is PrimitiveKind.CHAR -> writeChar(0)
-                is PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> writeBigDecimal(this, null)
-                else -> error("Encoding null for primitive $kind.")
+                is PrimitiveKind.FLOAT -> TODO()
+                is PrimitiveKind.DOUBLE -> this@PrimitiveElement.writeDouble(this, null)
+                else -> error("Don't know how to encode null for primitive $kind.")
             }
         }
 
@@ -88,24 +123,15 @@ class PrimitiveElement(
                 is PrimitiveKind.INT -> readInt()
                 is PrimitiveKind.LONG -> readLong()
                 is PrimitiveKind.CHAR -> readChar()
-                is PrimitiveKind.FLOAT -> readBigDecimal(this).toFloat()
-                is PrimitiveKind.DOUBLE -> readBigDecimal(this).toDouble()
+                is PrimitiveKind.FLOAT -> TODO()
+                is PrimitiveKind.DOUBLE -> this@PrimitiveElement.readDouble(this)
                 else -> error("Do not know how to decode primitive $kind")
             } as? T ?: error("$serialName cannot decode required type")
         }
 
-    private fun writeBigDecimal(output: DataOutput, surrogate: DoubleSurrogate?) {
-        val serialization = surrogate?.let { inlinedSerialize(surrogate) }
-            ?: ByteArray(DOUBLE_SIZE) { 0 }
-        output.write(serialization)
-    }
-
-    private fun readBigDecimal(input: DataInput): BigDecimal {
+    private fun readDouble(input: DataInput): Double {
         val surrogateInput = ByteArray(DOUBLE_SIZE)
         input.readFully(surrogateInput)
-
-        val surrogate = deserialize<DoubleSurrogate>(surrogateInput)
-
-        return surrogate.toOriginal()
+        return deserialize<DoubleSurrogate>(surrogateInput).toOriginal()
     }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/BigDecimalSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/BigDecimalSerializer.kt
@@ -53,10 +53,11 @@ data class BigDecimalSurrogate(
         private fun emptyByteArray(): ByteArray = ByteArray(0) { 0 }
         private fun String.toListOfDecimals(): ByteArray {
             return this.map {
-            // Experimental: prefer plain java version.
-            // it.digitToInt()
-            Character.getNumericValue(it).toByte()
-        }.toByteArray()
+                // Experimental: prefer plain java version.
+                // it.digitToInt()
+                Character.getNumericValue(it).toByte()
+            }.toByteArray()
+        }
 
         private fun representOrThrow(bigDecimal: BigDecimal): Pair<String, String?> {
             val integerFractionPair = bigDecimal.toPlainString().removePrefix("-").split(".")

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/BigDecimalSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/BigDecimalSerializer.kt
@@ -1,24 +1,11 @@
 package com.ing.serialization.bfl.serializers
 
+import com.ing.serialization.bfl.api.BaseSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 import java.math.BigDecimal
 
-object BigDecimalSerializer : KSerializer<BigDecimal> {
-    private val strategy = BigDecimalSurrogate.serializer()
-    override val descriptor: SerialDescriptor = strategy.descriptor
-    override fun serialize(encoder: Encoder, value: BigDecimal) {
-        encoder.encodeSerializableValue(strategy, BigDecimalSurrogate.from(value))
-    }
-
-    override fun deserialize(decoder: Decoder): BigDecimal {
-        val surrogate = decoder.decodeSerializableValue(strategy)
-        return surrogate.toOriginal()
-    }
-}
+object BigDecimalSerializer : KSerializer<BigDecimal> by (BaseSerializer(BigDecimalSurrogate.serializer()) { BigDecimalSurrogate.from(it) })
 
 @Suppress("ArrayInDataClass")
 @Serializable
@@ -26,8 +13,8 @@ data class BigDecimalSurrogate(
     override val sign: Byte,
     override val integer: ByteArray,
     override val fraction: ByteArray
-) : FloatingPointSurrogate {
-    fun toOriginal() = toBigDecimal()
+) : FloatingPointSurrogate<BigDecimal> {
+    override fun toOriginal() = toBigDecimal()
 
     companion object {
         fun from(bigDecimal: BigDecimal): BigDecimalSurrogate {

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import java.math.BigDecimal
 
 object DoubleSerializer : KSerializer<Double> {
     private val strategy = DoubleSurrogate.serializer()
@@ -24,19 +23,11 @@ object DoubleSerializer : KSerializer<Double> {
 @Suppress("ArrayInDataClass")
 @Serializable
 data class DoubleSurrogate(
-    val sign: Byte,
-    @FixedLength([DOUBLE_INTEGER_SIZE]) val integer: ByteArray,
-    @FixedLength([DOUBLE_FRACTION_SIZE]) val fraction: ByteArray
-) {
-    fun toOriginal(): Double {
-        val integer = this.integer.joinToString(separator = "") { "$it" }.trimStart('0')
-        val fraction = this.fraction.joinToString(separator = "") { "$it" }.trimEnd('0')
-        var digit = if (fraction.isEmpty()) integer else "$integer.$fraction"
-        if (this.sign == (-1).toByte()) {
-            digit = "-$digit"
-        }
-        return BigDecimal(digit).toDouble()
-    }
+    override val sign: Byte,
+    @FixedLength([DOUBLE_INTEGER_SIZE]) override val integer: ByteArray,
+    @FixedLength([DOUBLE_FRACTION_SIZE]) override val fraction: ByteArray
+) : FloatingPointSurrogate {
+    fun toOriginal() = toBigDecimal().toDouble()
 
     companion object {
         const val DOUBLE_INTEGER_SIZE: Int = 309
@@ -46,32 +37,8 @@ data class DoubleSurrogate(
         const val DOUBLE_SIZE = 1 + (4 + DOUBLE_INTEGER_SIZE) + (4 + DOUBLE_FRACTION_SIZE)
 
         fun from(double: Double): DoubleSurrogate {
-            val doubleAsBigDecimal = double.toBigDecimal()
-            val (integerPart, fractionalPart) = representOrThrow(doubleAsBigDecimal)
-
-            val sign = doubleAsBigDecimal.signum().toByte()
-            val integer = integerPart.toListOfDecimals()
-            val fraction = (fractionalPart?.toListOfDecimals() ?: ByteArray(0))
-
+            val (sign, integer, fraction) = double.toBigDecimal().asByteTriple()
             return DoubleSurrogate(sign, integer, fraction)
-        }
-
-        private fun String.toListOfDecimals(): ByteArray {
-            return this.map {
-                // Experimental: prefer plain java version.
-                // it.digitToInt()
-                Character.getNumericValue(it).toByte()
-            }.toByteArray()
-        }
-
-        private fun representOrThrow(bigDecimal: BigDecimal): Pair<String, String?> {
-            val integerFractionPair = bigDecimal.toPlainString().removePrefix("-").split(".")
-
-            val integerPart = integerFractionPair.getOrNull(0)
-                ?: error("Cannot convert BigDecimal ${bigDecimal.toPlainString()} to its integer and fractional parts")
-            val fractionalPart = integerFractionPair.getOrNull(1)
-
-            return Pair(integerPart, fractionalPart)
         }
     }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
@@ -1,0 +1,93 @@
+package com.ing.serialization.bfl.serializers
+
+import com.ing.serialization.bfl.annotations.FixedLength
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.math.BigDecimal
+
+typealias DoubleBigDecimal = BigDecimal
+
+object DoubleSerializer : KSerializer<DoubleBigDecimal> {
+    private val strategy = DoubleSurrogate.serializer()
+    override val descriptor: SerialDescriptor = strategy.descriptor
+    override fun serialize(encoder: Encoder, value: DoubleBigDecimal) {
+        encoder.encodeSerializableValue(strategy, DoubleSurrogate.from(value))
+    }
+
+    override fun deserialize(decoder: Decoder): DoubleBigDecimal {
+        val surrogate = decoder.decodeSerializableValue(strategy)
+        return surrogate.toOriginal()
+    }
+}
+
+@Suppress("ArrayInDataClass")
+@Serializable
+data class DoubleSurrogate(
+    val sign: Byte,
+    @FixedLength([DOUBLE_INTEGER_SIZE]) val integer: ByteArray,
+    @FixedLength([DOUBLE_FRACTION_SIZE]) val fraction: ByteArray
+) {
+    fun toOriginal(): BigDecimal {
+        val integer = this.integer.joinToString(separator = "") { "$it" }.trimStart('0')
+        val fraction = this.fraction.joinToString(separator = "") { "$it" }.trimEnd('0')
+        var digit = if (fraction.isEmpty()) integer else "$integer.$fraction"
+        if (this.sign == (-1).toByte()) {
+            digit = "-$digit"
+        }
+        return DoubleBigDecimal(digit)
+    }
+
+    companion object {
+        const val DOUBLE_INTEGER_SIZE: Int = 100
+        const val DOUBLE_FRACTION_SIZE: Int = 20
+        const val DOUBLE_SIZE = 1 + (4 + DOUBLE_INTEGER_SIZE) + (4 + DOUBLE_FRACTION_SIZE)
+
+        fun from(bigDecimal: DoubleBigDecimal): DoubleSurrogate {
+            val (integerPart, fractionalPart) = representOrThrow(bigDecimal)
+
+            val sign = bigDecimal.signum().toByte()
+
+            val integer = integerPart.toListOfDecimals()
+
+            val fraction = (fractionalPart?.toListOfDecimals() ?: emptyByteArray())
+
+            return DoubleSurrogate(sign, integer, fraction)
+        }
+
+        private fun emptyByteArray(): ByteArray = ByteArray(0) { 0 }
+        private fun String.toListOfDecimals(): ByteArray {
+            return this.map {
+                // Experimental: prefer plain java version.
+                // it.digitToInt()
+                Character.getNumericValue(it).toByte()
+            }.toByteArray()
+        }
+
+        internal fun from(float: Float) =
+            try {
+                from(float.toBigDecimal())
+            } catch (e: IllegalArgumentException) {
+                throw IllegalArgumentException("Float is too large for BigDecimalSurrogate", e)
+            }
+
+        internal fun from(double: Double) =
+            try {
+                from(double.toBigDecimal())
+            } catch (e: IllegalArgumentException) {
+                throw IllegalArgumentException("Double is too large for BigDecimalSurrogate", e)
+            }
+
+        private fun representOrThrow(bigDecimal: BigDecimal): Pair<String, String?> {
+            val integerFractionPair = bigDecimal.toPlainString().removePrefix("-").split(".")
+
+            val integerPart = integerFractionPair.getOrNull(0)
+                ?: error("Cannot convert BigDecimal ${bigDecimal.toPlainString()} to its integer and fractional parts")
+            val fractionalPart = integerFractionPair.getOrNull(1)
+
+            return Pair(integerPart, fractionalPart)
+        }
+    }
+}

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
@@ -1,24 +1,11 @@
 package com.ing.serialization.bfl.serializers
 
 import com.ing.serialization.bfl.annotations.FixedLength
+import com.ing.serialization.bfl.api.BaseSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 
-object DoubleSerializer : KSerializer<Double> {
-    private val strategy = DoubleSurrogate.serializer()
-    override val descriptor: SerialDescriptor = strategy.descriptor
-    override fun serialize(encoder: Encoder, value: Double) {
-        encoder.encodeSerializableValue(strategy, DoubleSurrogate.from(value))
-    }
-
-    override fun deserialize(decoder: Decoder): Double {
-        val surrogate = decoder.decodeSerializableValue(strategy)
-        return surrogate.toOriginal()
-    }
-}
+object DoubleSerializer : KSerializer<Double> by (BaseSerializer(DoubleSurrogate.serializer()) { DoubleSurrogate.from(it) })
 
 @Suppress("ArrayInDataClass")
 @Serializable
@@ -26,8 +13,8 @@ data class DoubleSurrogate(
     override val sign: Byte,
     @FixedLength([DOUBLE_INTEGER_SIZE]) override val integer: ByteArray,
     @FixedLength([DOUBLE_FRACTION_SIZE]) override val fraction: ByteArray
-) : FloatingPointSurrogate {
-    fun toOriginal() = toBigDecimal().toDouble()
+) : FloatingPointSurrogate<Double> {
+    override fun toOriginal() = toBigDecimal().toDouble()
 
     companion object {
         const val DOUBLE_INTEGER_SIZE: Int = 309

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatSerializer.kt
@@ -1,0 +1,31 @@
+package com.ing.serialization.bfl.serializers
+
+import com.ing.serialization.bfl.annotations.FixedLength
+import com.ing.serialization.bfl.api.BaseSerializer
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+
+object FloatSerializer : KSerializer<Float> by (BaseSerializer(FloatSurrogate.serializer()) { FloatSurrogate.from(it) })
+
+@Suppress("ArrayInDataClass")
+@Serializable
+data class FloatSurrogate(
+    override val sign: Byte,
+    @FixedLength([FLOAT_INTEGER_SIZE]) override val integer: ByteArray,
+    @FixedLength([FLOAT_FRACTION_SIZE]) override val fraction: ByteArray
+) : FloatingPointSurrogate<Float> {
+    override fun toOriginal() = toBigDecimal().toFloat()
+
+    companion object {
+        const val FLOAT_INTEGER_SIZE: Int = 39
+        const val FLOAT_FRACTION_SIZE: Int = 46
+
+        // TODO: @Victor: What are these magic numbers? Let's make constants for them somewhere
+        const val FLOAT_SIZE = 1 + (4 + FLOAT_INTEGER_SIZE) + (4 + FLOAT_FRACTION_SIZE)
+
+        fun from(double: Float): FloatSurrogate {
+            val (sign, integer, fraction) = double.toBigDecimal().asByteTriple()
+            return FloatSurrogate(sign, integer, fraction)
+        }
+    }
+}

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatingPointSurrogate.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatingPointSurrogate.kt
@@ -1,0 +1,19 @@
+package com.ing.serialization.bfl.serializers
+
+import java.math.BigDecimal
+
+interface FloatingPointSurrogate {
+    val sign: Byte
+    val integer: ByteArray
+    val fraction: ByteArray
+
+    fun toBigDecimal(): BigDecimal {
+        val integer = this.integer.joinToString(separator = "") { "$it" }.trimStart('0')
+        val fraction = this.fraction.joinToString(separator = "") { "$it" }.trimEnd('0')
+        var digit = if (fraction.isEmpty()) integer else "$integer.$fraction"
+        if (this.sign == (-1).toByte()) {
+            digit = "-$digit"
+        }
+        return BigDecimal(digit)
+    }
+}

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatingPointSurrogate.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatingPointSurrogate.kt
@@ -1,8 +1,9 @@
 package com.ing.serialization.bfl.serializers
 
+import com.ing.serialization.bfl.api.Surrogate
 import java.math.BigDecimal
 
-interface FloatingPointSurrogate {
+interface FloatingPointSurrogate<T> : Surrogate<T> {
     val sign: Byte
     val integer: ByteArray
     val fraction: ByteArray

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/SerializersModule.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/SerializersModule.kt
@@ -18,6 +18,7 @@ val BFLSerializers = SerializersModule {
     // Contextual types.
     contextual(BigDecimalSerializer)
     contextual(DoubleSerializer)
+    contextual(FloatSerializer)
     contextual(CurrencySerializer)
     contextual(DateSerializer)
     contextual(ZonedDateTimeSerializer)

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/SerializersModule.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/SerializersModule.kt
@@ -17,6 +17,7 @@ val BFLSerializers = SerializersModule {
     //
     // Contextual types.
     contextual(BigDecimalSerializer)
+    contextual(DoubleSerializer)
     contextual(CurrencySerializer)
     contextual(DateSerializer)
     contextual(ZonedDateTimeSerializer)

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/Util.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/Util.kt
@@ -1,0 +1,32 @@
+package com.ing.serialization.bfl.serializers
+
+import java.math.BigDecimal
+
+fun String.toListOfDecimals(): ByteArray {
+    return this.map {
+        // Experimental: prefer plain java version.
+        // it.digitToInt()
+        Character.getNumericValue(it).toByte()
+    }.toByteArray()
+}
+
+fun BigDecimal.representOrThrow(): Pair<String, String?> {
+    val integerFractionPair = toPlainString().removePrefix("-").split(".")
+
+    val integerPart = integerFractionPair.getOrNull(0)
+        ?: error("Cannot convert BigDecimal ${toPlainString()} to its integer and fractional parts")
+    val fractionalPart = integerFractionPair.getOrNull(1)
+
+    return Pair(integerPart, fractionalPart)
+}
+
+/**
+ * @return a triple containing the sign byte, the integer bytes and the fraction bytes
+ */
+fun BigDecimal.asByteTriple(): Triple<Byte, ByteArray, ByteArray> {
+    val (integerPart, fractionalPart) = representOrThrow()
+    val sign = signum().toByte()
+    val integer = integerPart.toListOfDecimals()
+    val fraction = (fractionalPart?.toListOfDecimals() ?: ByteArray(0))
+    return Triple(sign, integer, fraction)
+}

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/BigDecimalSerializerTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/BigDecimalSerializerTest.kt
@@ -1,6 +1,6 @@
 package com.ing.serialization.bfl.serde.serializers.custom
 
-import com.ing.serialization.bfl.api.serialize
+import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.serde.checkedSerialize
 import com.ing.serialization.bfl.serde.checkedSerializeInlined
 import com.ing.serialization.bfl.serde.roundTrip
@@ -18,7 +18,7 @@ import java.math.BigDecimal
 
 class BigDecimalSerializerTest {
     @Serializable
-    data class Data(val value: @Contextual BigDecimal)
+    data class Data(@FixedLength([20, 4]) val value: @Contextual BigDecimal)
 
     @Test
     fun `BigDecimalSurrogate should convert to BigDecimal`() {
@@ -71,8 +71,8 @@ class BigDecimalSerializerTest {
     fun `BigDecimal should be serialized successfully`() {
         val mask = listOf(
             Pair("sign", 1),
-            Pair("integer", 4 + BigDecimalSurrogate.INTEGER_SIZE),
-            Pair("fraction", 4 + BigDecimalSurrogate.FRACTION_SIZE)
+            Pair("integer", 4 + 20),
+            Pair("fraction", 4 + 4)
         )
 
         val data = Data(4.33.toBigDecimal())
@@ -96,8 +96,7 @@ class BigDecimalSerializerTest {
     @Test
     fun `different BigDecimals should have same size after serialization`() {
         val data1 = Data(4.33.toBigDecimal())
-        val maxBigDecimal = BigDecimal("${"9".repeat(BigDecimalSurrogate.INTEGER_SIZE)}.${"9".repeat(BigDecimalSurrogate.FRACTION_SIZE)}")
-        val data2 = Data(maxBigDecimal)
+        val data2 = Data(BigDecimal("0.01"))
 
         sameSizeInlined(data1, data2)
         sameSize(data1, data2)

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/BigDecimalSerializerTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/BigDecimalSerializerTest.kt
@@ -7,13 +7,11 @@ import com.ing.serialization.bfl.serde.roundTrip
 import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
-import com.ing.serialization.bfl.serializers.BFLSerializers
 import com.ing.serialization.bfl.serializers.BigDecimalSurrogate
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 
 class BigDecimalSerializerTest {
@@ -35,37 +33,44 @@ class BigDecimalSerializerTest {
         ).forEach {
             BigDecimalSurrogate(
                 it.first.first,
-                ByteArray(BigDecimalSurrogate.INTEGER_SIZE - it.first.second.size) { 0 } + it.first.second,
-                it.first.third + ByteArray(BigDecimalSurrogate.FRACTION_SIZE - it.first.third.size) { 0 }
+                it.first.second,
+                it.first.third
             ).toOriginal() shouldBe it.second.toBigDecimal()
         }
     }
 
-    @Test
-    fun `BigDecimalSurrogate init should throw IllegalArgumentException when integer size is incorrect`() {
-        assertThrows<IllegalArgumentException> {
-            BigDecimalSurrogate(
-                1.toByte(),
-                byteArrayOf(4),
-                byteArrayOf(3, 3)
-            )
-        }.also {
-            it.message shouldBe "Integer part must have size no longer than ${BigDecimalSurrogate.INTEGER_SIZE}, but has ${byteArrayOf(4).size}"
-        }
-    }
+    /** TODO: Commented out all tests that depend on hardcoded sizes, as n/a for BigDecimalSurrogate now */
 
-    @Test
-    fun `BigDecimalSurrogate init should throw IllegalArgumentException when fraction size is incorrect`() {
-        assertThrows<IllegalArgumentException> {
-            BigDecimalSurrogate(
-                1.toByte(),
-                ByteArray(BigDecimalSurrogate.INTEGER_SIZE - byteArrayOf(4).size) { 0 } + byteArrayOf(4),
-                byteArrayOf(3, 3)
-            )
-        }.also {
-            it.message shouldBe "Fraction part must have size no longer than ${BigDecimalSurrogate.FRACTION_SIZE}, but has ${byteArrayOf(3, 3).size}"
-        }
-    }
+    //    @Test
+//    fun `BigDecimalSurrogate init should throw IllegalArgumentException when integer size is incorrect`() {
+//        assertThrows<IllegalArgumentException> {
+//            BigDecimalSurrogate(
+//                1.toByte(),
+//                byteArrayOf(4),
+//                byteArrayOf(3, 3)
+//            )
+//        }.also {
+//            it.message shouldBe "Integer part must have size no longer than ${BigDecimalSurrogate.INTEGER_SIZE}, but has ${byteArrayOf(4).size}"
+//        }
+//    }
+//
+//    @Test
+//    fun `BigDecimalSurrogate init should throw IllegalArgumentException when fraction size is incorrect`() {
+//        assertThrows<IllegalArgumentException> {
+//            BigDecimalSurrogate(
+//                1.toByte(),
+//                ByteArray(BigDecimalSurrogate.INTEGER_SIZE - byteArrayOf(4).size) { 0 } + byteArrayOf(4),
+//                byteArrayOf(3, 3)
+//            )
+//        }.also {
+//            it.message shouldBe "Fraction part must have size no longer than ${BigDecimalSurrogate.FRACTION_SIZE}, but has ${
+//                byteArrayOf(
+//                    3,
+//                    3
+//                ).size
+//            }"
+//        }
+//    }
 
     @Test
     fun `BigDecimal should be serialized successfully`() {
@@ -102,27 +107,29 @@ class BigDecimalSerializerTest {
         sameSize(data1, data2)
     }
 
-    @Test
-    fun `serialize BigDecimal should throw IllegalArgumentException when integer size limit is not respected`() {
-        val integerOverSized = BigDecimal("${"9".repeat(BigDecimalSurrogate.INTEGER_SIZE + 1)}.${"9".repeat(BigDecimalSurrogate.FRACTION_SIZE)}")
+//    @Test
+//    fun `serialize BigDecimal should throw IllegalArgumentException when integer size limit is not respected`() {
+//        val integerOverSized =
+//            BigDecimal("${"9".repeat(BigDecimalSurrogate.INTEGER_SIZE + 1)}.${"9".repeat(BigDecimalSurrogate.FRACTION_SIZE)}")
+//
+//        assertThrows<IllegalArgumentException> {
+//            serialize(Data(integerOverSized), BFLSerializers)
+//        }.also {
+//            it.message shouldBe "BigDecimal supports no more than ${BigDecimalSurrogate.INTEGER_SIZE} digits in integer part " +
+//                "and ${BigDecimalSurrogate.FRACTION_SIZE} digits in fraction part"
+//        }
+//    }
 
-        assertThrows<IllegalArgumentException> {
-            serialize(Data(integerOverSized), BFLSerializers)
-        }.also {
-            it.message shouldBe "BigDecimal supports no more than ${BigDecimalSurrogate.INTEGER_SIZE} digits in integer part " +
-                "and ${BigDecimalSurrogate.FRACTION_SIZE} digits in fraction part"
-        }
-    }
-
-    @Test
-    fun `serialize BigDecimal should throw IllegalArgumentException when fraction size limit is not respected`() {
-        val fractionOverSized = BigDecimal("${"9".repeat(BigDecimalSurrogate.INTEGER_SIZE)}.${"9".repeat(BigDecimalSurrogate.FRACTION_SIZE + 1)}")
-
-        assertThrows<IllegalArgumentException> {
-            serialize(Data(fractionOverSized), BFLSerializers)
-        }.also {
-            it.message shouldBe "BigDecimal supports no more than ${BigDecimalSurrogate.INTEGER_SIZE} digits in integer part " +
-                "and ${BigDecimalSurrogate.FRACTION_SIZE} digits in fraction part"
-        }
-    }
+//    @Test
+//    fun `serialize BigDecimal should throw IllegalArgumentException when fraction size limit is not respected`() {
+//        val fractionOverSized =
+//            BigDecimal("${"9".repeat(BigDecimalSurrogate.INTEGER_SIZE)}.${"9".repeat(BigDecimalSurrogate.FRACTION_SIZE + 1)}")
+//
+//        assertThrows<IllegalArgumentException> {
+//            serialize(Data(fractionOverSized), BFLSerializers)
+//        }.also {
+//            it.message shouldBe "BigDecimal supports no more than ${BigDecimalSurrogate.INTEGER_SIZE} digits in integer part " +
+//                "and ${BigDecimalSurrogate.FRACTION_SIZE} digits in fraction part"
+//        }
+//    }
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/DoubleTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/DoubleTest.kt
@@ -1,17 +1,16 @@
 package com.ing.serialization.bfl.serde.serializers.custom
 
 import com.ing.serialization.bfl.api.serialize
+import com.ing.serialization.bfl.serde.SerdeError
 import com.ing.serialization.bfl.serde.checkedSerialize
 import com.ing.serialization.bfl.serde.checkedSerializeInlined
 import com.ing.serialization.bfl.serde.roundTrip
 import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
+import com.ing.serialization.bfl.serializers.BFLSerializers
 import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_FRACTION_SIZE
 import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_INTEGER_SIZE
-import com.ing.serialization.bfl.serializers.BFLSerializers
-import com.ing.serialization.bfl.serializers.BigDecimalSurrogate
-import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -65,10 +64,8 @@ class DoubleTest {
             Double.MAX_VALUE,
             Double.MIN_VALUE,
         ).forEach {
-            assertThrows<IllegalArgumentException> {
+            assertThrows<SerdeError.CollectionTooLarge> {
                 serialize(Data(it), BFLSerializers)
-            }.also {
-                it.message shouldBe "Double is too large for BigDecimalSurrogate"
             }
         }
     }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/DoubleTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/DoubleTest.kt
@@ -62,8 +62,8 @@ class DoubleTest {
     fun `Serialization is lossless for min and max values`() {
         listOf(
             4.33,
-//            Double.MAX_VALUE,
-//            Double.MIN_VALUE,
+            Double.MAX_VALUE,
+            Double.MIN_VALUE,
         ).forEach { expected ->
             val (serialized, layout) = debugSerialize(Data(expected), BFLSerializers)
             val actual = deserialize<Data>(serialized)

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/DoubleTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/DoubleTest.kt
@@ -62,8 +62,8 @@ class DoubleTest {
     fun `Serialization is lossless for min and max values`() {
         listOf(
             4.33,
-            Double.MAX_VALUE,
-            Double.MIN_VALUE,
+//            Double.MAX_VALUE,
+//            Double.MIN_VALUE,
         ).forEach { expected ->
             val (serialized, layout) = debugSerialize(Data(expected), BFLSerializers)
             val actual = deserialize<Data>(serialized)

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/DoubleTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/DoubleTest.kt
@@ -7,6 +7,8 @@ import com.ing.serialization.bfl.serde.roundTrip
 import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
+import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_FRACTION_SIZE
+import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_INTEGER_SIZE
 import com.ing.serialization.bfl.serializers.BFLSerializers
 import com.ing.serialization.bfl.serializers.BigDecimalSurrogate
 import io.kotest.matchers.shouldBe
@@ -23,8 +25,8 @@ class DoubleTest {
         val mask = listOf(
             Pair("nonNull", 1),
             Pair("sign", 1),
-            Pair("integer", 4 + BigDecimalSurrogate.DOUBLE_INTEGER_SIZE),
-            Pair("fraction", 4 + BigDecimalSurrogate.DOUBLE_FRACTION_SIZE)
+            Pair("integer", 4 + DOUBLE_INTEGER_SIZE),
+            Pair("fraction", 4 + DOUBLE_FRACTION_SIZE)
         )
 
         val data = Data(4.33)
@@ -46,8 +48,8 @@ class DoubleTest {
     fun `different Doubles should have same size after serialization`() {
         val data1 = Data(4.33)
         val double = (
-            List(BigDecimalSurrogate.DOUBLE_INTEGER_SIZE / 10) { "1234567890" }.joinToString(separator = "") + "." +
-                List(BigDecimalSurrogate.DOUBLE_FRACTION_SIZE / 10) { "1234567890" }.joinToString(separator = "")
+            List(DOUBLE_INTEGER_SIZE / 10) { "1234567890" }.joinToString(separator = "") + "." +
+                List(DOUBLE_FRACTION_SIZE / 10) { "1234567890" }.joinToString(separator = "")
             ).toDouble()
 
         val data2 = Data(double)

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/DoubleTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/DoubleTest.kt
@@ -23,8 +23,8 @@ class DoubleTest {
         val mask = listOf(
             Pair("nonNull", 1),
             Pair("sign", 1),
-            Pair("integer", 4 + BigDecimalSurrogate.INTEGER_SIZE),
-            Pair("fraction", 4 + BigDecimalSurrogate.FRACTION_SIZE)
+            Pair("integer", 4 + BigDecimalSurrogate.DOUBLE_INTEGER_SIZE),
+            Pair("fraction", 4 + BigDecimalSurrogate.DOUBLE_FRACTION_SIZE)
         )
 
         val data = Data(4.33)
@@ -46,8 +46,8 @@ class DoubleTest {
     fun `different Doubles should have same size after serialization`() {
         val data1 = Data(4.33)
         val double = (
-            List(BigDecimalSurrogate.INTEGER_SIZE / 10) { "1234567890" }.joinToString(separator = "") + "." +
-                List(BigDecimalSurrogate.FRACTION_SIZE / 10) { "1234567890" }.joinToString(separator = "")
+            List(BigDecimalSurrogate.DOUBLE_INTEGER_SIZE / 10) { "1234567890" }.joinToString(separator = "") + "." +
+                List(BigDecimalSurrogate.DOUBLE_FRACTION_SIZE / 10) { "1234567890" }.joinToString(separator = "")
             ).toDouble()
 
         val data2 = Data(double)

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/FloatTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/FloatTest.kt
@@ -1,17 +1,16 @@
 package com.ing.serialization.bfl.serde.serializers.custom
 
 import com.ing.serialization.bfl.api.serialize
+import com.ing.serialization.bfl.serde.SerdeError
 import com.ing.serialization.bfl.serde.checkedSerialize
 import com.ing.serialization.bfl.serde.checkedSerializeInlined
 import com.ing.serialization.bfl.serde.roundTrip
 import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
+import com.ing.serialization.bfl.serializers.BFLSerializers
 import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_FRACTION_SIZE
 import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_INTEGER_SIZE
-import com.ing.serialization.bfl.serializers.BFLSerializers
-import com.ing.serialization.bfl.serializers.BigDecimalSurrogate
-import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -58,10 +57,8 @@ class FloatTest {
     fun `serialize Float should throw IllegalArgumentException when size limit is not respected`() {
         val floatOverSized = Float.MIN_VALUE
 
-        assertThrows<IllegalArgumentException> {
+        assertThrows<SerdeError.CollectionTooLarge> {
             serialize(Data(floatOverSized), BFLSerializers)
-        }.also {
-            it.message shouldBe "Float is too large for BigDecimalSurrogate"
         }
     }
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/FloatTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/FloatTest.kt
@@ -7,6 +7,8 @@ import com.ing.serialization.bfl.serde.roundTrip
 import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
+import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_FRACTION_SIZE
+import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_INTEGER_SIZE
 import com.ing.serialization.bfl.serializers.BFLSerializers
 import com.ing.serialization.bfl.serializers.BigDecimalSurrogate
 import io.kotest.matchers.shouldBe
@@ -23,8 +25,8 @@ class FloatTest {
         val mask = listOf(
             Pair("nonNull", 1),
             Pair("sign", 1),
-            Pair("integer", 4 + BigDecimalSurrogate.DOUBLE_INTEGER_SIZE),
-            Pair("fraction", 4 + BigDecimalSurrogate.DOUBLE_FRACTION_SIZE)
+            Pair("integer", 4 + DOUBLE_INTEGER_SIZE),
+            Pair("fraction", 4 + DOUBLE_FRACTION_SIZE)
         )
 
         val data = Data(4.33.toFloat())

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/FloatTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/FloatTest.kt
@@ -1,7 +1,7 @@
 package com.ing.serialization.bfl.serde.serializers.custom
 
-import com.ing.serialization.bfl.api.serialize
-import com.ing.serialization.bfl.serde.SerdeError
+import com.ing.serialization.bfl.api.reified.debugSerialize
+import com.ing.serialization.bfl.api.reified.deserialize
 import com.ing.serialization.bfl.serde.checkedSerialize
 import com.ing.serialization.bfl.serde.checkedSerializeInlined
 import com.ing.serialization.bfl.serde.roundTrip
@@ -9,11 +9,11 @@ import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
 import com.ing.serialization.bfl.serializers.BFLSerializers
-import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_FRACTION_SIZE
-import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_INTEGER_SIZE
+import com.ing.serialization.bfl.serializers.FloatSurrogate.Companion.FLOAT_FRACTION_SIZE
+import com.ing.serialization.bfl.serializers.FloatSurrogate.Companion.FLOAT_INTEGER_SIZE
+import io.kotest.matchers.floats.shouldBeExactly
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class FloatTest {
     @Serializable
@@ -24,8 +24,8 @@ class FloatTest {
         val mask = listOf(
             Pair("nonNull", 1),
             Pair("sign", 1),
-            Pair("integer", 4 + DOUBLE_INTEGER_SIZE),
-            Pair("fraction", 4 + DOUBLE_FRACTION_SIZE)
+            Pair("integer", 4 + FLOAT_INTEGER_SIZE),
+            Pair("fraction", 4 + FLOAT_FRACTION_SIZE)
         )
 
         val data = Data(4.33.toFloat())
@@ -54,11 +54,15 @@ class FloatTest {
     }
 
     @Test
-    fun `serialize Float should throw IllegalArgumentException when size limit is not respected`() {
-        val floatOverSized = Float.MIN_VALUE
-
-        assertThrows<SerdeError.CollectionTooLarge> {
-            serialize(Data(floatOverSized), BFLSerializers)
+    fun `Serialization is lossless for min and max values`() {
+        listOf(
+            4.33F,
+            Float.MAX_VALUE,
+            Float.MIN_VALUE,
+        ).forEach { expected ->
+            val (serialized, layout) = debugSerialize(FloatTest.Data(expected), BFLSerializers)
+            val actual = deserialize<FloatTest.Data>(serialized)
+            actual.value!! shouldBeExactly expected
         }
     }
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/FloatTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/FloatTest.kt
@@ -23,8 +23,8 @@ class FloatTest {
         val mask = listOf(
             Pair("nonNull", 1),
             Pair("sign", 1),
-            Pair("integer", 4 + BigDecimalSurrogate.INTEGER_SIZE),
-            Pair("fraction", 4 + BigDecimalSurrogate.FRACTION_SIZE)
+            Pair("integer", 4 + BigDecimalSurrogate.DOUBLE_INTEGER_SIZE),
+            Pair("fraction", 4 + BigDecimalSurrogate.DOUBLE_FRACTION_SIZE)
         )
 
         val data = Data(4.33.toFloat())


### PR DESCRIPTION
This is a PoC. Please don't pay attention to commit messages, copy-paste, etc. It is just for discussion on concept level.

Essentially did the following:

- Split serializers and surrogates for BigDecimal and Double/Float.
- The BigDecimal surrogate has no hardcoded FixedLength annotations, so the user is allowed/required to set it. This can be seen in the test.
- The Double surrogate is used for both Double and Float and is still hardcoded.
- Removed the logic that padded the BigDecimal when creating the surrogate in `from()` and let the BFL do its normal padding work based on FixedLength info for the integer and fraction bytearrays. Downside is that the integer is now also big-endian, which is not compatible with the current Zinc implementation. Upside is that it is consistent with all other sizing done by BFL.

If this idea seems like a good idea, it will need a lot of cleanup still. There is also a lot of duplication between these serializers now. Also good to make a separate one for Float, since it can be shorter length than Double.