### PR TITLE
Separate serializers for Float, Double and BD

### DIFF
--- a/src/main/kotlin/com/ing/serialization/bfl/serde/SerialDescriptorUtils.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/SerialDescriptorUtils.kt
@@ -28,4 +28,5 @@ val SerialDescriptor.simpleSerialName: String
     get() = serialName.split(".").last()
 
 val SerialKind.isTrulyPrimitive: Boolean
-    get() = this is PrimitiveKind && this !is PrimitiveKind.STRING
+    get() = this is PrimitiveKind &&
+        this !is PrimitiveKind.STRING

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
@@ -1,15 +1,17 @@
 package com.ing.serialization.bfl.serde.element
 
 import com.ing.serialization.bfl.api.reified.deserialize
+import com.ing.serialization.bfl.api.reified.serialize
 import com.ing.serialization.bfl.serde.SerdeError
 import com.ing.serialization.bfl.serde.isTrulyPrimitive
-import com.ing.serialization.bfl.serializers.BigDecimalSurrogate
+import com.ing.serialization.bfl.serializers.DoubleSurrogate
+import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_SIZE
+import com.ing.serialization.bfl.serializers.FloatSurrogate
+import com.ing.serialization.bfl.serializers.FloatSurrogate.Companion.FLOAT_SIZE
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialKind
 import java.io.DataInput
 import java.io.DataOutput
-import java.math.BigDecimal
-import com.ing.serialization.bfl.api.reified.serialize as inlinedSerialize
 
 /**
  * The basic abstraction of each object being serialized.
@@ -33,7 +35,8 @@ class PrimitiveElement(
             is PrimitiveKind.INT -> 4
             is PrimitiveKind.LONG -> 8
             is PrimitiveKind.CHAR -> 2
-            is PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> BigDecimalSurrogate.SIZE
+            is PrimitiveKind.FLOAT -> FLOAT_SIZE
+            is PrimitiveKind.DOUBLE -> DOUBLE_SIZE
             else -> error("Do not know how to compute layout for primitive $kind")
         }
 
@@ -50,17 +53,25 @@ class PrimitiveElement(
                 kind is PrimitiveKind.INT && value is Int -> writeInt(value)
                 kind is PrimitiveKind.LONG && value is Long -> writeLong(value)
                 kind is PrimitiveKind.CHAR && value is Char -> writeChar(value.toInt())
-                kind is PrimitiveKind.FLOAT && value is Float -> {
-                    val surrogate = BigDecimalSurrogate.from(value)
-                    writeBigDecimal(stream, surrogate)
-                }
-                kind is PrimitiveKind.DOUBLE && value is Double -> {
-                    val surrogate = BigDecimalSurrogate.from(value)
-                    writeBigDecimal(stream, surrogate)
-                }
+                kind is PrimitiveKind.FLOAT && value is Float -> writeFloat(stream, value)
+                kind is PrimitiveKind.DOUBLE && value is Double -> writeDouble(stream, value)
                 else -> error("$serialName cannot encode $value of type ${value::class.simpleName}")
             }
         }
+    }
+
+    private fun writeFloat(stream: DataOutput, value: Float?) {
+        when (value) {
+            is Float -> serialize(FloatSurrogate.from(value))
+            else -> ByteArray(FLOAT_SIZE) { 0 }
+        }.also { stream.write(it) }
+    }
+
+    private fun writeDouble(stream: DataOutput, value: Double?) {
+        when (value) {
+            is Double -> serialize(DoubleSurrogate.from(value))
+            else -> ByteArray(DOUBLE_SIZE) { 0 }
+        }.also { stream.write(it) }
     }
 
     override fun encodeNull(output: DataOutput) =
@@ -72,8 +83,9 @@ class PrimitiveElement(
                 is PrimitiveKind.INT -> writeInt(0)
                 is PrimitiveKind.LONG -> writeLong(0)
                 is PrimitiveKind.CHAR -> writeChar(0)
-                is PrimitiveKind.FLOAT, PrimitiveKind.DOUBLE -> writeBigDecimal(this, null)
-                else -> error("Encoding null for primitive $kind.")
+                is PrimitiveKind.FLOAT -> writeFloat(this, null)
+                is PrimitiveKind.DOUBLE -> writeDouble(this, null)
+                else -> error("Don't know how to encode null for primitive $kind.")
             }
         }
 
@@ -87,24 +99,21 @@ class PrimitiveElement(
                 is PrimitiveKind.INT -> readInt()
                 is PrimitiveKind.LONG -> readLong()
                 is PrimitiveKind.CHAR -> readChar()
-                is PrimitiveKind.FLOAT -> readBigDecimal(this).toFloat()
-                is PrimitiveKind.DOUBLE -> readBigDecimal(this).toDouble()
+                is PrimitiveKind.FLOAT -> this@PrimitiveElement.readFloat(this)
+                is PrimitiveKind.DOUBLE -> this@PrimitiveElement.readDouble(this)
                 else -> error("Do not know how to decode primitive $kind")
             } as? T ?: error("$serialName cannot decode required type")
         }
 
-    private fun writeBigDecimal(output: DataOutput, surrogate: BigDecimalSurrogate?) {
-        val serialization = surrogate?.let { inlinedSerialize(surrogate) }
-            ?: ByteArray(BigDecimalSurrogate.SIZE) { 0 }
-        output.write(serialization)
+    private fun readFloat(input: DataInput): Float {
+        val surrogateInput = ByteArray(FLOAT_SIZE)
+        input.readFully(surrogateInput)
+        return deserialize<FloatSurrogate>(surrogateInput).toOriginal()
     }
 
-    private fun readBigDecimal(input: DataInput): BigDecimal {
-        val surrogateInput = ByteArray(BigDecimalSurrogate.SIZE)
+    private fun readDouble(input: DataInput): Double {
+        val surrogateInput = ByteArray(DOUBLE_SIZE)
         input.readFully(surrogateInput)
-
-        val surrogate = deserialize<BigDecimalSurrogate>(surrogateInput)
-
-        return surrogate.toOriginal()
+        return deserialize<DoubleSurrogate>(surrogateInput).toOriginal()
     }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
@@ -5,9 +5,7 @@ import com.ing.serialization.bfl.api.reified.serialize
 import com.ing.serialization.bfl.serde.SerdeError
 import com.ing.serialization.bfl.serde.isTrulyPrimitive
 import com.ing.serialization.bfl.serializers.DoubleSurrogate
-import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_SIZE
 import com.ing.serialization.bfl.serializers.FloatSurrogate
-import com.ing.serialization.bfl.serializers.FloatSurrogate.Companion.FLOAT_SIZE
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.SerialKind
 import java.io.DataInput
@@ -35,8 +33,8 @@ class PrimitiveElement(
             is PrimitiveKind.INT -> 4
             is PrimitiveKind.LONG -> 8
             is PrimitiveKind.CHAR -> 2
-            is PrimitiveKind.FLOAT -> FLOAT_SIZE
-            is PrimitiveKind.DOUBLE -> DOUBLE_SIZE
+            is PrimitiveKind.FLOAT -> FloatSurrogate.FLOAT_SIZE
+            is PrimitiveKind.DOUBLE -> DoubleSurrogate.DOUBLE_SIZE
             else -> error("Do not know how to compute layout for primitive $kind")
         }
 
@@ -61,17 +59,11 @@ class PrimitiveElement(
     }
 
     private fun writeFloat(stream: DataOutput, value: Float?) {
-        when (value) {
-            is Float -> serialize(FloatSurrogate.from(value))
-            else -> ByteArray(FLOAT_SIZE) { 0 }
-        }.also { stream.write(it) }
+        stream.write(value?.let { serialize(FloatSurrogate.from(it)) } ?: ByteArray(FloatSurrogate.FLOAT_SIZE) { 0 })
     }
 
     private fun writeDouble(stream: DataOutput, value: Double?) {
-        when (value) {
-            is Double -> serialize(DoubleSurrogate.from(value))
-            else -> ByteArray(DOUBLE_SIZE) { 0 }
-        }.also { stream.write(it) }
+        stream.write(value?.let { serialize(DoubleSurrogate.from(it)) } ?: ByteArray(DoubleSurrogate.DOUBLE_SIZE) { 0 })
     }
 
     override fun encodeNull(output: DataOutput) =
@@ -106,13 +98,13 @@ class PrimitiveElement(
         }
 
     private fun readFloat(input: DataInput): Float {
-        val surrogateInput = ByteArray(FLOAT_SIZE)
+        val surrogateInput = ByteArray(FloatSurrogate.FLOAT_SIZE)
         input.readFully(surrogateInput)
         return deserialize<FloatSurrogate>(surrogateInput).toOriginal()
     }
 
     private fun readDouble(input: DataInput): Double {
-        val surrogateInput = ByteArray(DOUBLE_SIZE)
+        val surrogateInput = ByteArray(DoubleSurrogate.DOUBLE_SIZE)
         input.readFully(surrogateInput)
         return deserialize<DoubleSurrogate>(surrogateInput).toOriginal()
     }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/BigDecimalSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/BigDecimalSerializer.kt
@@ -1,9 +1,12 @@
 package com.ing.serialization.bfl.serializers
 
+import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.api.BaseSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import java.math.BigDecimal
+
+typealias BigDecimalSizes = FixedLength
 
 object BigDecimalSerializer : KSerializer<BigDecimal> by (BaseSerializer(BigDecimalSurrogate.serializer()) { BigDecimalSurrogate.from(it) })
 

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/BigDecimalSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/BigDecimalSerializer.kt
@@ -1,102 +1,25 @@
 package com.ing.serialization.bfl.serializers
 
-import com.ing.serialization.bfl.annotations.FixedLength
+import com.ing.serialization.bfl.api.BaseSerializer
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 import java.math.BigDecimal
 
-object BigDecimalSerializer : KSerializer<BigDecimal> {
-    private val strategy = BigDecimalSurrogate.serializer()
-    override val descriptor: SerialDescriptor = strategy.descriptor
-    override fun serialize(encoder: Encoder, value: BigDecimal) {
-        encoder.encodeSerializableValue(strategy, BigDecimalSurrogate.from(value))
-    }
-
-    override fun deserialize(decoder: Decoder): BigDecimal {
-        val surrogate = decoder.decodeSerializableValue(strategy)
-        return surrogate.toOriginal()
-    }
-}
+object BigDecimalSerializer : KSerializer<BigDecimal> by (BaseSerializer(BigDecimalSurrogate.serializer()) { BigDecimalSurrogate.from(it) })
 
 @Suppress("ArrayInDataClass")
 @Serializable
 data class BigDecimalSurrogate(
-    val sign: Byte,
-    @FixedLength([INTEGER_SIZE]) val integer: ByteArray,
-    @FixedLength([FRACTION_SIZE]) val fraction: ByteArray
-) {
-    init {
-        require(integer.size == INTEGER_SIZE) {
-            "Integer part must have size no longer than $INTEGER_SIZE, but has ${integer.size}"
-        }
-        require(fraction.size == FRACTION_SIZE) {
-            "Fraction part must have size no longer than $FRACTION_SIZE, but has ${fraction.size}"
-        }
-    }
-
-    fun toOriginal(): BigDecimal {
-        val integer = this.integer.joinToString(separator = "") { "$it" }.trimStart('0')
-        val fraction = this.fraction.joinToString(separator = "") { "$it" }.trimEnd('0')
-        var digit = if (fraction.isEmpty()) integer else "$integer.$fraction"
-        if (this.sign == (-1).toByte()) {
-            digit = "-$digit"
-        }
-        return BigDecimal(digit)
-    }
+    override val sign: Byte,
+    override val integer: ByteArray,
+    override val fraction: ByteArray
+) : FloatingPointSurrogate<BigDecimal> {
+    override fun toOriginal() = toBigDecimal()
 
     companion object {
-        const val INTEGER_SIZE: Int = 100
-        const val FRACTION_SIZE: Int = 20
-        const val SIZE = 1 + (4 + INTEGER_SIZE) + (4 + FRACTION_SIZE)
-
         fun from(bigDecimal: BigDecimal): BigDecimalSurrogate {
-            val (integerPart, fractionalPart) = representOrThrow(bigDecimal)
-
-            val sign = bigDecimal.signum().toByte()
-
-            val integer = ByteArray(INTEGER_SIZE - integerPart.length) { 0 } +
-                integerPart.toListOfDecimals()
-
-            val fraction = (fractionalPart?.toListOfDecimals() ?: ByteArray(0)) +
-                ByteArray(FRACTION_SIZE - (fractionalPart?.length ?: 0)) { 0 }
-
+            val (sign, integer, fraction) = bigDecimal.asByteTriple()
             return BigDecimalSurrogate(sign, integer, fraction)
-        }
-
-        private fun String.toListOfDecimals() = map {
-            // Experimental: prefer plain java version.
-            // it.digitToInt()
-            Character.getNumericValue(it).toByte()
-        }.toByteArray()
-
-        internal fun from(float: Float) =
-            try {
-                from(float.toBigDecimal())
-            } catch (e: IllegalArgumentException) {
-                throw IllegalArgumentException("Float is too large for BigDecimalSurrogate", e)
-            }
-
-        internal fun from(double: Double) =
-            try {
-                from(double.toBigDecimal())
-            } catch (e: IllegalArgumentException) {
-                throw IllegalArgumentException("Double is too large for BigDecimalSurrogate", e)
-            }
-
-        private fun representOrThrow(bigDecimal: BigDecimal): Pair<String, String?> {
-            val integerFractionPair = bigDecimal.toPlainString().removePrefix("-").split(".")
-
-            val integerPart = integerFractionPair[0]
-            val fractionalPart = integerFractionPair.getOrNull(1)
-
-            require(integerPart.length <= INTEGER_SIZE && (fractionalPart?.length ?: 0) <= FRACTION_SIZE) {
-                "BigDecimal supports no more than $INTEGER_SIZE digits in integer part and $FRACTION_SIZE digits in fraction part"
-            }
-
-            return Pair(integerPart, fractionalPart)
         }
     }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
@@ -20,7 +20,7 @@ data class DoubleSurrogate(
         const val DOUBLE_INTEGER_SIZE: Int = 309
         const val DOUBLE_FRACTION_SIZE: Int = 325
 
-        // TODO: @Victor: What are these magic numbers? Let's make constants for them somewhere
+        // TODO: introduce constants for these magic numbers, also in PrimitiveElement.kt
         const val DOUBLE_SIZE = 1 + (4 + DOUBLE_INTEGER_SIZE) + (4 + DOUBLE_FRACTION_SIZE)
 
         fun from(double: Double): DoubleSurrogate {

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
@@ -1,0 +1,31 @@
+package com.ing.serialization.bfl.serializers
+
+import com.ing.serialization.bfl.annotations.FixedLength
+import com.ing.serialization.bfl.api.BaseSerializer
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+
+object DoubleSerializer : KSerializer<Double> by (BaseSerializer(DoubleSurrogate.serializer()) { DoubleSurrogate.from(it) })
+
+@Suppress("ArrayInDataClass")
+@Serializable
+data class DoubleSurrogate(
+    override val sign: Byte,
+    @FixedLength([DOUBLE_INTEGER_SIZE]) override val integer: ByteArray,
+    @FixedLength([DOUBLE_FRACTION_SIZE]) override val fraction: ByteArray
+) : FloatingPointSurrogate<Double> {
+    override fun toOriginal() = toBigDecimal().toDouble()
+
+    companion object {
+        const val DOUBLE_INTEGER_SIZE: Int = 309
+        const val DOUBLE_FRACTION_SIZE: Int = 325
+
+        // TODO: @Victor: What are these magic numbers? Let's make constants for them somewhere
+        const val DOUBLE_SIZE = 1 + (4 + DOUBLE_INTEGER_SIZE) + (4 + DOUBLE_FRACTION_SIZE)
+
+        fun from(double: Double): DoubleSurrogate {
+            val (sign, integer, fraction) = double.toBigDecimal().asByteTriple()
+            return DoubleSurrogate(sign, integer, fraction)
+        }
+    }
+}

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
@@ -20,7 +20,7 @@ data class DoubleSurrogate(
         const val DOUBLE_INTEGER_SIZE: Int = 309
         const val DOUBLE_FRACTION_SIZE: Int = 325
 
-        // TODO: introduce constants for these magic numbers, also in PrimitiveElement.kt
+        // TODO: introduce constants for these magic numbers, also in PrimitiveElement.kt, tests and any other places they occur.
         const val DOUBLE_SIZE = 1 + (4 + DOUBLE_INTEGER_SIZE) + (4 + DOUBLE_FRACTION_SIZE)
 
         fun from(double: Double): DoubleSurrogate {

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatSerializer.kt
@@ -1,0 +1,31 @@
+package com.ing.serialization.bfl.serializers
+
+import com.ing.serialization.bfl.annotations.FixedLength
+import com.ing.serialization.bfl.api.BaseSerializer
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+
+object FloatSerializer : KSerializer<Float> by (BaseSerializer(FloatSurrogate.serializer()) { FloatSurrogate.from(it) })
+
+@Suppress("ArrayInDataClass")
+@Serializable
+data class FloatSurrogate(
+    override val sign: Byte,
+    @FixedLength([FLOAT_INTEGER_SIZE]) override val integer: ByteArray,
+    @FixedLength([FLOAT_FRACTION_SIZE]) override val fraction: ByteArray
+) : FloatingPointSurrogate<Float> {
+    override fun toOriginal() = toBigDecimal().toFloat()
+
+    companion object {
+        const val FLOAT_INTEGER_SIZE: Int = 39
+        const val FLOAT_FRACTION_SIZE: Int = 46
+
+        // TODO: @Victor: What are these magic numbers? Let's make constants for them somewhere
+        const val FLOAT_SIZE = 1 + (4 + FLOAT_INTEGER_SIZE) + (4 + FLOAT_FRACTION_SIZE)
+
+        fun from(double: Float): FloatSurrogate {
+            val (sign, integer, fraction) = double.toBigDecimal().asByteTriple()
+            return FloatSurrogate(sign, integer, fraction)
+        }
+    }
+}

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatSerializer.kt
@@ -20,7 +20,7 @@ data class FloatSurrogate(
         const val FLOAT_INTEGER_SIZE: Int = 39
         const val FLOAT_FRACTION_SIZE: Int = 46
 
-        // TODO: @Victor: What are these magic numbers? Let's make constants for them somewhere
+        // TODO: introduce constants for these magic numbers, also in PrimitiveElement.kt, tests and any other places they occur.
         const val FLOAT_SIZE = 1 + (4 + FLOAT_INTEGER_SIZE) + (4 + FLOAT_FRACTION_SIZE)
 
         fun from(double: Float): FloatSurrogate {

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatingPointSurrogate.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatingPointSurrogate.kt
@@ -1,0 +1,20 @@
+package com.ing.serialization.bfl.serializers
+
+import com.ing.serialization.bfl.api.Surrogate
+import java.math.BigDecimal
+
+interface FloatingPointSurrogate<T> : Surrogate<T> {
+    val sign: Byte
+    val integer: ByteArray
+    val fraction: ByteArray
+
+    fun toBigDecimal(): BigDecimal {
+        val integer = this.integer.joinToString(separator = "") { "$it" }.trimStart('0')
+        val fraction = this.fraction.joinToString(separator = "") { "$it" }.trimEnd('0')
+        var digit = if (fraction.isEmpty()) integer else "$integer.$fraction"
+        if (this.sign == (-1).toByte()) {
+            digit = "-$digit"
+        }
+        return BigDecimal(digit)
+    }
+}

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/SerializersModule.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/SerializersModule.kt
@@ -17,6 +17,8 @@ val BFLSerializers = SerializersModule {
     //
     // Contextual types.
     contextual(BigDecimalSerializer)
+    contextual(DoubleSerializer)
+    contextual(FloatSerializer)
     contextual(CurrencySerializer)
     contextual(DateSerializer)
     contextual(ZonedDateTimeSerializer)

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/Util.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/Util.kt
@@ -1,0 +1,32 @@
+package com.ing.serialization.bfl.serializers
+
+import java.math.BigDecimal
+
+fun String.toListOfDecimals(): ByteArray {
+    return this.map {
+        // Experimental: prefer plain java version.
+        // it.digitToInt()
+        Character.getNumericValue(it).toByte()
+    }.toByteArray()
+}
+
+fun BigDecimal.representOrThrow(): Pair<String, String?> {
+    val integerFractionPair = toPlainString().removePrefix("-").split(".")
+
+    val integerPart = integerFractionPair.getOrNull(0)
+        ?: error("Cannot convert BigDecimal ${toPlainString()} to its integer and fractional parts")
+    val fractionalPart = integerFractionPair.getOrNull(1)
+
+    return Pair(integerPart, fractionalPart)
+}
+
+/**
+ * @return a triple containing the sign byte, the integer bytes and the fraction bytes
+ */
+fun BigDecimal.asByteTriple(): Triple<Byte, ByteArray, ByteArray> {
+    val (integerPart, fractionalPart) = representOrThrow()
+    val sign = signum().toByte()
+    val integer = integerPart.toListOfDecimals()
+    val fraction = (fractionalPart?.toListOfDecimals() ?: ByteArray(0))
+    return Triple(sign, integer, fraction)
+}

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/Util.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/Util.kt
@@ -2,19 +2,14 @@ package com.ing.serialization.bfl.serializers
 
 import java.math.BigDecimal
 
-fun String.toListOfDecimals(): ByteArray {
-    return this.map {
-        // Experimental: prefer plain java version.
-        // it.digitToInt()
-        Character.getNumericValue(it).toByte()
-    }.toByteArray()
-}
+fun String.toListOfDecimals() = map {
+    Character.getNumericValue(it).toByte()
+}.toByteArray()
 
 fun BigDecimal.representOrThrow(): Pair<String, String?> {
     val integerFractionPair = toPlainString().removePrefix("-").split(".")
 
-    val integerPart = integerFractionPair.getOrNull(0)
-        ?: error("Cannot convert BigDecimal ${toPlainString()} to its integer and fractional parts")
+    val integerPart = integerFractionPair[0]
     val fractionalPart = integerFractionPair.getOrNull(1)
 
     return Pair(integerPart, fractionalPart)

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/BigDecimalSerializerTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/BigDecimalSerializerTest.kt
@@ -1,24 +1,22 @@
 package com.ing.serialization.bfl.serde.serializers.custom
 
-import com.ing.serialization.bfl.api.serialize
+import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.serde.checkedSerialize
 import com.ing.serialization.bfl.serde.checkedSerializeInlined
 import com.ing.serialization.bfl.serde.roundTrip
 import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
-import com.ing.serialization.bfl.serializers.BFLSerializers
 import com.ing.serialization.bfl.serializers.BigDecimalSurrogate
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import java.math.BigDecimal
 
 class BigDecimalSerializerTest {
     @Serializable
-    data class Data(val value: @Contextual BigDecimal)
+    data class Data(@FixedLength([20, 4]) val value: @Contextual BigDecimal)
 
     @Test
     fun `BigDecimalSurrogate should convert to BigDecimal`() {
@@ -35,44 +33,51 @@ class BigDecimalSerializerTest {
         ).forEach {
             BigDecimalSurrogate(
                 it.first.first,
-                ByteArray(BigDecimalSurrogate.INTEGER_SIZE - it.first.second.size) { 0 } + it.first.second,
-                it.first.third + ByteArray(BigDecimalSurrogate.FRACTION_SIZE - it.first.third.size) { 0 }
+                it.first.second,
+                it.first.third
             ).toOriginal() shouldBe it.second.toBigDecimal()
         }
     }
 
-    @Test
-    fun `BigDecimalSurrogate init should throw IllegalArgumentException when integer size is incorrect`() {
-        assertThrows<IllegalArgumentException> {
-            BigDecimalSurrogate(
-                1.toByte(),
-                byteArrayOf(4),
-                byteArrayOf(3, 3)
-            )
-        }.also {
-            it.message shouldBe "Integer part must have size no longer than ${BigDecimalSurrogate.INTEGER_SIZE}, but has ${byteArrayOf(4).size}"
-        }
-    }
+    /** TODO: Commented out all tests that depend on hardcoded sizes, as n/a for BigDecimalSurrogate now */
 
-    @Test
-    fun `BigDecimalSurrogate init should throw IllegalArgumentException when fraction size is incorrect`() {
-        assertThrows<IllegalArgumentException> {
-            BigDecimalSurrogate(
-                1.toByte(),
-                ByteArray(BigDecimalSurrogate.INTEGER_SIZE - byteArrayOf(4).size) { 0 } + byteArrayOf(4),
-                byteArrayOf(3, 3)
-            )
-        }.also {
-            it.message shouldBe "Fraction part must have size no longer than ${BigDecimalSurrogate.FRACTION_SIZE}, but has ${byteArrayOf(3, 3).size}"
-        }
-    }
+    //    @Test
+//    fun `BigDecimalSurrogate init should throw IllegalArgumentException when integer size is incorrect`() {
+//        assertThrows<IllegalArgumentException> {
+//            BigDecimalSurrogate(
+//                1.toByte(),
+//                byteArrayOf(4),
+//                byteArrayOf(3, 3)
+//            )
+//        }.also {
+//            it.message shouldBe "Integer part must have size no longer than ${BigDecimalSurrogate.INTEGER_SIZE}, but has ${byteArrayOf(4).size}"
+//        }
+//    }
+//
+//    @Test
+//    fun `BigDecimalSurrogate init should throw IllegalArgumentException when fraction size is incorrect`() {
+//        assertThrows<IllegalArgumentException> {
+//            BigDecimalSurrogate(
+//                1.toByte(),
+//                ByteArray(BigDecimalSurrogate.INTEGER_SIZE - byteArrayOf(4).size) { 0 } + byteArrayOf(4),
+//                byteArrayOf(3, 3)
+//            )
+//        }.also {
+//            it.message shouldBe "Fraction part must have size no longer than ${BigDecimalSurrogate.FRACTION_SIZE}, but has ${
+//                byteArrayOf(
+//                    3,
+//                    3
+//                ).size
+//            }"
+//        }
+//    }
 
     @Test
     fun `BigDecimal should be serialized successfully`() {
         val mask = listOf(
             Pair("sign", 1),
-            Pair("integer", 4 + BigDecimalSurrogate.INTEGER_SIZE),
-            Pair("fraction", 4 + BigDecimalSurrogate.FRACTION_SIZE)
+            Pair("integer", 4 + 20),
+            Pair("fraction", 4 + 4)
         )
 
         val data = Data(4.33.toBigDecimal())
@@ -96,34 +101,35 @@ class BigDecimalSerializerTest {
     @Test
     fun `different BigDecimals should have same size after serialization`() {
         val data1 = Data(4.33.toBigDecimal())
-        val maxBigDecimal = BigDecimal("${"9".repeat(BigDecimalSurrogate.INTEGER_SIZE)}.${"9".repeat(BigDecimalSurrogate.FRACTION_SIZE)}")
-        val data2 = Data(maxBigDecimal)
+        val data2 = Data(BigDecimal("0.01"))
 
         sameSizeInlined(data1, data2)
         sameSize(data1, data2)
     }
 
-    @Test
-    fun `serialize BigDecimal should throw IllegalArgumentException when integer size limit is not respected`() {
-        val integerOverSized = BigDecimal("${"9".repeat(BigDecimalSurrogate.INTEGER_SIZE + 1)}.${"9".repeat(BigDecimalSurrogate.FRACTION_SIZE)}")
+//    @Test
+//    fun `serialize BigDecimal should throw IllegalArgumentException when integer size limit is not respected`() {
+//        val integerOverSized =
+//            BigDecimal("${"9".repeat(BigDecimalSurrogate.INTEGER_SIZE + 1)}.${"9".repeat(BigDecimalSurrogate.FRACTION_SIZE)}")
+//
+//        assertThrows<IllegalArgumentException> {
+//            serialize(Data(integerOverSized), BFLSerializers)
+//        }.also {
+//            it.message shouldBe "BigDecimal supports no more than ${BigDecimalSurrogate.INTEGER_SIZE} digits in integer part " +
+//                "and ${BigDecimalSurrogate.FRACTION_SIZE} digits in fraction part"
+//        }
+//    }
 
-        assertThrows<IllegalArgumentException> {
-            serialize(Data(integerOverSized), BFLSerializers)
-        }.also {
-            it.message shouldBe "BigDecimal supports no more than ${BigDecimalSurrogate.INTEGER_SIZE} digits in integer part " +
-                "and ${BigDecimalSurrogate.FRACTION_SIZE} digits in fraction part"
-        }
-    }
-
-    @Test
-    fun `serialize BigDecimal should throw IllegalArgumentException when fraction size limit is not respected`() {
-        val fractionOverSized = BigDecimal("${"9".repeat(BigDecimalSurrogate.INTEGER_SIZE)}.${"9".repeat(BigDecimalSurrogate.FRACTION_SIZE + 1)}")
-
-        assertThrows<IllegalArgumentException> {
-            serialize(Data(fractionOverSized), BFLSerializers)
-        }.also {
-            it.message shouldBe "BigDecimal supports no more than ${BigDecimalSurrogate.INTEGER_SIZE} digits in integer part " +
-                "and ${BigDecimalSurrogate.FRACTION_SIZE} digits in fraction part"
-        }
-    }
+//    @Test
+//    fun `serialize BigDecimal should throw IllegalArgumentException when fraction size limit is not respected`() {
+//        val fractionOverSized =
+//            BigDecimal("${"9".repeat(BigDecimalSurrogate.INTEGER_SIZE)}.${"9".repeat(BigDecimalSurrogate.FRACTION_SIZE + 1)}")
+//
+//        assertThrows<IllegalArgumentException> {
+//            serialize(Data(fractionOverSized), BFLSerializers)
+//        }.also {
+//            it.message shouldBe "BigDecimal supports no more than ${BigDecimalSurrogate.INTEGER_SIZE} digits in integer part " +
+//                "and ${BigDecimalSurrogate.FRACTION_SIZE} digits in fraction part"
+//        }
+//    }
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/BigDecimalSerializerTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/BigDecimalSerializerTest.kt
@@ -1,12 +1,12 @@
 package com.ing.serialization.bfl.serde.serializers.custom
 
-import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.serde.checkedSerialize
 import com.ing.serialization.bfl.serde.checkedSerializeInlined
 import com.ing.serialization.bfl.serde.roundTrip
 import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
+import com.ing.serialization.bfl.serializers.BigDecimalSizes
 import com.ing.serialization.bfl.serializers.BigDecimalSurrogate
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Contextual
@@ -16,7 +16,7 @@ import java.math.BigDecimal
 
 class BigDecimalSerializerTest {
     @Serializable
-    data class Data(@FixedLength([20, 4]) val value: @Contextual BigDecimal)
+    data class Data(@BigDecimalSizes([20, 4]) val value: @Contextual BigDecimal)
 
     @Test
     fun `BigDecimalSurrogate should convert to BigDecimal`() {
@@ -38,39 +38,6 @@ class BigDecimalSerializerTest {
             ).toOriginal() shouldBe it.second.toBigDecimal()
         }
     }
-
-    /** TODO: Commented out all tests that depend on hardcoded sizes, as n/a for BigDecimalSurrogate now */
-
-    //    @Test
-//    fun `BigDecimalSurrogate init should throw IllegalArgumentException when integer size is incorrect`() {
-//        assertThrows<IllegalArgumentException> {
-//            BigDecimalSurrogate(
-//                1.toByte(),
-//                byteArrayOf(4),
-//                byteArrayOf(3, 3)
-//            )
-//        }.also {
-//            it.message shouldBe "Integer part must have size no longer than ${BigDecimalSurrogate.INTEGER_SIZE}, but has ${byteArrayOf(4).size}"
-//        }
-//    }
-//
-//    @Test
-//    fun `BigDecimalSurrogate init should throw IllegalArgumentException when fraction size is incorrect`() {
-//        assertThrows<IllegalArgumentException> {
-//            BigDecimalSurrogate(
-//                1.toByte(),
-//                ByteArray(BigDecimalSurrogate.INTEGER_SIZE - byteArrayOf(4).size) { 0 } + byteArrayOf(4),
-//                byteArrayOf(3, 3)
-//            )
-//        }.also {
-//            it.message shouldBe "Fraction part must have size no longer than ${BigDecimalSurrogate.FRACTION_SIZE}, but has ${
-//                byteArrayOf(
-//                    3,
-//                    3
-//                ).size
-//            }"
-//        }
-//    }
 
     @Test
     fun `BigDecimal should be serialized successfully`() {
@@ -106,30 +73,4 @@ class BigDecimalSerializerTest {
         sameSizeInlined(data1, data2)
         sameSize(data1, data2)
     }
-
-//    @Test
-//    fun `serialize BigDecimal should throw IllegalArgumentException when integer size limit is not respected`() {
-//        val integerOverSized =
-//            BigDecimal("${"9".repeat(BigDecimalSurrogate.INTEGER_SIZE + 1)}.${"9".repeat(BigDecimalSurrogate.FRACTION_SIZE)}")
-//
-//        assertThrows<IllegalArgumentException> {
-//            serialize(Data(integerOverSized), BFLSerializers)
-//        }.also {
-//            it.message shouldBe "BigDecimal supports no more than ${BigDecimalSurrogate.INTEGER_SIZE} digits in integer part " +
-//                "and ${BigDecimalSurrogate.FRACTION_SIZE} digits in fraction part"
-//        }
-//    }
-
-//    @Test
-//    fun `serialize BigDecimal should throw IllegalArgumentException when fraction size limit is not respected`() {
-//        val fractionOverSized =
-//            BigDecimal("${"9".repeat(BigDecimalSurrogate.INTEGER_SIZE)}.${"9".repeat(BigDecimalSurrogate.FRACTION_SIZE + 1)}")
-//
-//        assertThrows<IllegalArgumentException> {
-//            serialize(Data(fractionOverSized), BFLSerializers)
-//        }.also {
-//            it.message shouldBe "BigDecimal supports no more than ${BigDecimalSurrogate.INTEGER_SIZE} digits in integer part " +
-//                "and ${BigDecimalSurrogate.FRACTION_SIZE} digits in fraction part"
-//        }
-//    }
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/DoubleTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/DoubleTest.kt
@@ -9,8 +9,7 @@ import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
 import com.ing.serialization.bfl.serializers.BFLSerializers
-import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_FRACTION_SIZE
-import com.ing.serialization.bfl.serializers.DoubleSurrogate.Companion.DOUBLE_INTEGER_SIZE
+import com.ing.serialization.bfl.serializers.DoubleSurrogate
 import io.kotest.matchers.doubles.shouldBeExactly
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
@@ -24,8 +23,8 @@ class DoubleTest {
         val mask = listOf(
             Pair("nonNull", 1),
             Pair("sign", 1),
-            Pair("integer", 4 + DOUBLE_INTEGER_SIZE),
-            Pair("fraction", 4 + DOUBLE_FRACTION_SIZE)
+            Pair("integer", 4 + DoubleSurrogate.DOUBLE_INTEGER_SIZE),
+            Pair("fraction", 4 + DoubleSurrogate.DOUBLE_FRACTION_SIZE)
         )
 
         val data = Data(4.33)
@@ -46,8 +45,8 @@ class DoubleTest {
     @Test
     fun `different Doubles should have same size after serialization`() {
         val double = (
-            List(DOUBLE_INTEGER_SIZE / 10) { "1234567890" }.joinToString(separator = "") + "." +
-                List(DOUBLE_FRACTION_SIZE / 10) { "1234567890" }.joinToString(separator = "")
+            List(DoubleSurrogate.DOUBLE_INTEGER_SIZE / 10) { "1234567890" }.joinToString(separator = "") + "." +
+                List(DoubleSurrogate.DOUBLE_FRACTION_SIZE / 10) { "1234567890" }.joinToString(separator = "")
             ).toDouble()
 
         val data1 = Data(4.33)

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/FloatTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/FloatTest.kt
@@ -9,8 +9,7 @@ import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
 import com.ing.serialization.bfl.serializers.BFLSerializers
-import com.ing.serialization.bfl.serializers.FloatSurrogate.Companion.FLOAT_FRACTION_SIZE
-import com.ing.serialization.bfl.serializers.FloatSurrogate.Companion.FLOAT_INTEGER_SIZE
+import com.ing.serialization.bfl.serializers.FloatSurrogate
 import io.kotest.matchers.floats.shouldBeExactly
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
@@ -24,8 +23,8 @@ class FloatTest {
         val mask = listOf(
             Pair("nonNull", 1),
             Pair("sign", 1),
-            Pair("integer", 4 + FLOAT_INTEGER_SIZE),
-            Pair("fraction", 4 + FLOAT_FRACTION_SIZE)
+            Pair("integer", 4 + FloatSurrogate.FLOAT_INTEGER_SIZE),
+            Pair("fraction", 4 + FloatSurrogate.FLOAT_FRACTION_SIZE)
         )
 
         val data = Data(4.33.toFloat())


### PR DESCRIPTION
This PR creates separate serializers for Float, Double and BigDecimal.
Float and Double have hardcoded fixed lengths. BigDecimal expects a FixedLength annotation.