### PR TITLE
Make Layout more verbose

### DIFF
--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/CollectionElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/CollectionElement.kt
@@ -21,8 +21,8 @@ class CollectionElement(
      */
     override val inherentLayout by lazy {
         listOf(
-            Pair("length", 4),
-            Pair("value", requiredLength * elementSize)
+            Pair("[Collection] original length bytecount", 4),
+            Pair("[Collection] value length", requiredLength * elementSize)
         )
     }
 

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/Element.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/Element.kt
@@ -25,7 +25,7 @@ abstract class Element(val serialName: String, val propertyName: String, val inn
     }
 
     val layout: Layout by lazy {
-        Layout(serialName, nullLayout + inherentLayout, inner.map { it.layout })
+        Layout(propertyName, serialName, nullLayout + inherentLayout, inner.map { it.layout })
     }
 
     val size by lazy {

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/Layout.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/Layout.kt
@@ -1,14 +1,15 @@
 package com.ing.serialization.bfl.serde.element
 
 class Layout(
-    val name: String,
+    val propertyName: String,
+    val serialName: String,
     val mask: List<Pair<String, Int>>,
     val inner: List<Layout> = listOf()
 ) {
     private fun toString(prefix: String = ""): String {
-        val deepPrefix = "$prefix "
-        return "$prefix$name\n$deepPrefix" +
-            mask.joinToString(separator = "\n$deepPrefix") { "${it.first} - ${it.second}" } +
+        val deepPrefix = "$prefix  "
+        return "${prefix}Element: $propertyName ($serialName)" +
+            "\n$deepPrefix" + mask.joinToString(separator = "\n$deepPrefix") { "${it.first}: ${it.second}" } +
             "\n" +
             if (inner.isNotEmpty()) {
                 inner.joinToString(separator = "") { it.toString(deepPrefix) }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
@@ -38,7 +38,7 @@ class PrimitiveElement(
             else -> error("Do not know how to compute layout for primitive $kind")
         }
 
-        listOf(Pair("value", size))
+        listOf(Pair("[Primitive] value length", size))
     }
 
     @Suppress("ComplexMethod")

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/StringElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/StringElement.kt
@@ -18,8 +18,8 @@ class StringElement(
      * SHORT (string length) + requiredLength * length(CHAR)
      */
     override val inherentLayout = listOf(
-        Pair("length", 2),
-        Pair("value", requiredLength * 2)
+        Pair("[String] original length bytecount", 2),
+        Pair("[String] value length", requiredLength * 2)
     )
 
     /**

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/StructureElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/StructureElement.kt
@@ -9,7 +9,7 @@ class StructureElement(
     override val isNullable: Boolean
 ) : Element(serialName, propertyName, inner) {
     override val inherentLayout by lazy {
-        listOf(Pair("length", constituentsSize))
+        listOf(Pair("[Structure] length", constituentsSize))
     }
 
     private val constituentsSize by lazy {


### PR DESCRIPTION
* Added `propertyName` to `Layout`
* Made `Layout.toString` more verbose

Example output for:
```kotlin
data class Data(@BigDecimalSizes([10, 4]) val value: @Contextual BigDecimal) 
```

Output:
```
Element: Data (com.ing.serialization.bfl.serde.serializers.custom.BigDecimalSerializerTest.Data)
  [Structure] length: 23
  Element: Data.value (com.ing.serialization.bfl.serializers.BigDecimalSurrogate)
    [Structure] length: 23
    Element: Data.value.sign (kotlin.Byte)
      [Primitive] value length: 1
    Element: Data.value.integer (kotlin.ByteArray)
      [Collection] original length bytecount: 4
      [Collection] value length: 10
      Element: Data.value.integer (kotlin.Byte)
        [Primitive] value length: 1
    Element: Data.value.fraction (kotlin.ByteArray)
      [Collection] original length bytecount: 4
      [Collection] value length: 4
      Element: Data.value.fraction (kotlin.Byte)
        [Primitive] value length: 1
```