### PR TITLE
Add convenience functions to API

### DIFF
--- a/src/main/kotlin/com/ing/serialization/bfl/api/Api.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/api/Api.kt
@@ -15,6 +15,11 @@ private fun <T : Any> SerializersModule.getSerializerFor(type: KClass<out T>): K
 
 fun <T : Any> serialize(
     data: T,
+    serializersModule: SerializersModule = EmptySerializersModule
+) = serialize(data, null, serializersModule)
+
+fun <T : Any> serialize(
+    data: T,
     strategy: KSerializer<T>? = null,
     serializersModule: SerializersModule = EmptySerializersModule
 ): ByteArray {

--- a/src/main/kotlin/com/ing/serialization/bfl/api/reified/Api.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/api/reified/Api.kt
@@ -13,6 +13,11 @@ import kotlinx.serialization.serializer
 
 inline fun <reified T : Any> serialize(
     data: T,
+    serializersModule: SerializersModule = EmptySerializersModule
+) = serialize(data, null, serializersModule)
+
+inline fun <reified T : Any> serialize(
+    data: T,
     strategy: KSerializer<T>? = null,
     serializersModule: SerializersModule = EmptySerializersModule
 ): ByteArray {


### PR DESCRIPTION
Adding back two convenience forms of `serialize` that used to be present
before 0.1.19. This is a very common form, where a user wants to
override the `SerializersModule`, but not the strategy.