### PR TITLE
Fix issue with trimmed zero in big decimal

### DIFF
--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatingPointSurrogate.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatingPointSurrogate.kt
@@ -9,8 +9,8 @@ interface FloatingPointSurrogate<T> : Surrogate<T> {
     val fraction: ByteArray
 
     fun toBigDecimal(): BigDecimal {
-        val integer = this.integer.reversedArray().joinToString(separator = "") { "$it" }.trimStart('0')
-        val fraction = this.fraction.joinToString(separator = "") { "$it" }.trimEnd('0')
+        val integer = this.integer.reversedArray().joinToString(separator = "") { "$it" }
+        val fraction = this.fraction.joinToString(separator = "") { "$it" }
         var digit = if (fraction.isEmpty()) integer else "$integer.$fraction"
         if (this.sign == (-1).toByte()) {
             digit = "-$digit"

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/Util.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/Util.kt
@@ -19,7 +19,7 @@ fun BigDecimal.representOrThrow(): Pair<String, String?> {
  * The encoding is as follows:
  * - sign: -1, 0 or 1
  * - integer: little-endian encoded ByteArray, so the number 123 is encoded as ByteArray(3): [3, 2, 1]
- * - fraction: big-endian encoded ByteArray, so the number 123 is encoced as ByteArray(3): [1, 2, 3]
+ * - fraction: big-endian encoded ByteArray, so the number 123 is encoded as ByteArray(3): [1, 2, 3]
  * @return a triple containing the sign byte, the integer bytes and the fraction bytes
  */
 fun BigDecimal.asByteTriple(): Triple<Byte, ByteArray, ByteArray> {

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/BigDecimalSerializerTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/BigDecimalSerializerTest.kt
@@ -67,6 +67,8 @@ class BigDecimalSerializerTest {
             Data(4.33.toBigDecimal()),
             Data((-4.33).toBigDecimal()),
             Data(BigDecimal.TEN),
+            Data(BigDecimal("0001.010")),
+            Data(BigDecimal("1.1000")),
             Data(BigDecimal("0.01"))
         ).forEach { data ->
             roundTripInlined(data)


### PR DESCRIPTION
**Bug** in BigDecimal Serializer: 

- **Description**: BigDecimals with **trailing zeros in their fractional part** were **not deserialized properly** after serialization 
- **Examples**: 
  - **1.00** was deserialized to **1** instead of **1.00**
  - **1.010** was deserialized to **1.01** instead of **1.010**
- **Root cause**: **Trimming** of trailing zeros for the fractional part in `FloatingPointSurrogate.toBigDecimal()`

**Fix**: **Remove trimming** from both the **integer** and the **fractional** part

- In the **integer** part, trimming is **redundant** since BigDecimal itself removes leading zeros
 - In the **fractional** part, trimming is **wrong** since it leads to erroneous deserialization
