### PR TITLE
Allow top level serialization of non-structure types and collections.

### DIFF
--- a/src/main/kotlin/com/ing/serialization/bfl/api/Utils.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/api/Utils.kt
@@ -10,18 +10,29 @@ import java.io.ByteArrayOutputStream
 import java.io.DataInputStream
 import java.io.DataOutputStream
 
-fun <T : Any> genericSerialize(data: T, serializersModule: SerializersModule, serializer: KSerializer<T>): ByteArray =
+fun <T : Any> genericSerialize(
+    data: T,
+    serializersModule: SerializersModule,
+    serializer: KSerializer<T>,
+    outerFixedLength: IntArray
+): ByteArray =
     ByteArrayOutputStream().use { output ->
         DataOutputStream(output).use { stream ->
-            BinaryFixedLengthOutputEncoder(stream, serializersModule).encodeSerializableValue(serializer, data)
+            BinaryFixedLengthOutputEncoder(stream, serializersModule, outerFixedLength)
+                .encodeSerializableValue(serializer, data)
         }
         output.toByteArray()
     }
 
-fun <T : Any> genericDebugSerialize(data: T, serializersModule: SerializersModule, serializer: KSerializer<T>): Pair<ByteArray, Layout> =
+fun <T : Any> genericDebugSerialize(
+    data: T,
+    serializersModule: SerializersModule,
+    serializer: KSerializer<T>,
+    outerFixedLength: IntArray
+): Pair<ByteArray, Layout> =
     ByteArrayOutputStream().use { output ->
         val layout = DataOutputStream(output).use { stream ->
-            val bfl = BinaryFixedLengthOutputEncoder(stream, serializersModule)
+            val bfl = BinaryFixedLengthOutputEncoder(stream, serializersModule, outerFixedLength)
             bfl.encodeSerializableValue(serializer, data)
             bfl.layout
         }
@@ -31,12 +42,13 @@ fun <T : Any> genericDebugSerialize(data: T, serializersModule: SerializersModul
 fun <T : Any> genericDeserialize(
     data: ByteArray,
     serializersModule: SerializersModule,
-    serializer: KSerializer<T>
+    serializer: KSerializer<T>,
+    outerFixedLength: IntArray
 ): T {
     return ByteArrayInputStream(data).use { input ->
         DataInputStream(input).use { stream ->
-            val bfl = BinaryFixedLengthInputDecoder(stream, serializersModule)
-            bfl.decodeSerializableValue(serializer)
+            BinaryFixedLengthInputDecoder(stream, serializersModule, outerFixedLength)
+                .decodeSerializableValue(serializer)
         }
     }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/api/reified/Api.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/api/reified/Api.kt
@@ -14,28 +14,31 @@ import kotlinx.serialization.serializer
 inline fun <reified T : Any> serialize(
     data: T,
     strategy: KSerializer<T>? = null,
-    serializersModule: SerializersModule = EmptySerializersModule
+    serializersModule: SerializersModule = EmptySerializersModule,
+    outerFixedLength: IntArray = IntArray(0)
 ): ByteArray {
     val serializer = getSerializer(strategy, serializersModule)
-    return genericSerialize(data, serializersModule, serializer)
+    return genericSerialize(data, serializersModule, serializer, outerFixedLength)
 }
 
 inline fun <reified T : Any> debugSerialize(
     data: T,
     strategy: KSerializer<T>? = null,
-    serializersModule: SerializersModule = EmptySerializersModule
+    serializersModule: SerializersModule = EmptySerializersModule,
+    outerFixedLength: IntArray = IntArray(0)
 ): Pair<ByteArray, Layout> {
     val serializer = getSerializer(strategy, serializersModule)
-    return genericDebugSerialize(data, serializersModule, serializer)
+    return genericDebugSerialize(data, serializersModule, serializer, outerFixedLength)
 }
 
 inline fun <reified T : Any> deserialize(
     data: ByteArray,
     strategy: KSerializer<T>? = null,
-    serializersModule: SerializersModule = EmptySerializersModule
+    serializersModule: SerializersModule = EmptySerializersModule,
+    outerFixedLength: IntArray = IntArray(0)
 ): T {
     val serializer = getSerializer(strategy, serializersModule)
-    return genericDeserialize(data, serializersModule, serializer)
+    return genericDeserialize(data, serializersModule, serializer, outerFixedLength)
 }
 
 inline fun <reified T : Any> getSerializer(

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/Tests.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/Tests.kt
@@ -19,9 +19,10 @@ inline fun <reified T : Any> checkedSerializeInlined(
     data: T,
     mask: List<Pair<String, Int>>,
     serializers: SerializersModule = EmptySerializersModule,
-    strategy: KSerializer<T>? = null
+    strategy: KSerializer<T>? = null,
+    outerFixedLength: IntArray = IntArray(0)
 ): ByteArray {
-    val bytes = serializeInlined(data, strategy, serializersModule = BFLSerializers + serializers)
+    val bytes = serializeInlined(data, strategy, serializersModule = BFLSerializers + serializers, outerFixedLength = outerFixedLength)
     log(bytes, mask)
     bytes.size shouldBe mask.sumBy { it.second }
 
@@ -34,10 +35,11 @@ inline fun <reified T : Any> checkedSerializeInlined(
 inline fun <reified T : Any> roundTripInlined(
     value: T,
     serializers: SerializersModule = EmptySerializersModule,
-    strategy: KSerializer<T>? = null
+    strategy: KSerializer<T>? = null,
+    outerFixedLength: IntArray = IntArray(0)
 ) {
-    val serialization = serializeInlined(value, strategy, serializersModule = BFLSerializers + serializers)
-    val deserialization = deserializeInlined<T>(serialization, serializersModule = BFLSerializers + serializers)
+    val serialization = serializeInlined(value, strategy, serializersModule = BFLSerializers + serializers, outerFixedLength = outerFixedLength)
+    val deserialization = deserializeInlined<T>(serialization, serializersModule = BFLSerializers + serializers, outerFixedLength = outerFixedLength)
 
     deserialization shouldBe value
 }
@@ -49,12 +51,13 @@ inline fun <reified T : Any> sameSizeInlined(
     value1: T,
     value2: T,
     serializers: SerializersModule = EmptySerializersModule,
-    strategy: KSerializer<T>? = null
+    strategy: KSerializer<T>? = null,
+    outerFixedLength: IntArray = IntArray(0)
 ) {
     value1 shouldNotBe value2
 
-    val serialization1 = serializeInlined(value1, strategy, serializersModule = BFLSerializers + serializers)
-    val serialization2 = serializeInlined(value2, strategy, serializersModule = BFLSerializers + serializers)
+    val serialization1 = serializeInlined(value1, strategy, serializersModule = BFLSerializers + serializers, outerFixedLength = outerFixedLength)
+    val serialization2 = serializeInlined(value2, strategy, serializersModule = BFLSerializers + serializers, outerFixedLength = outerFixedLength)
 
     serialization1 shouldNotBe serialization2
     serialization1.size shouldBe serialization2.size
@@ -67,9 +70,10 @@ fun <T : Any> checkedSerialize(
     data: T,
     mask: List<Pair<String, Int>>,
     serializers: SerializersModule = EmptySerializersModule,
-    strategy: KSerializer<T>? = null
+    strategy: KSerializer<T>? = null,
+    outerFixedLength: IntArray = IntArray(0)
 ): ByteArray {
-    val bytes = serialize(data, strategy, serializersModule = BFLSerializers + serializers)
+    val bytes = serialize(data, strategy, serializersModule = BFLSerializers + serializers, outerFixedLength = outerFixedLength)
     log(bytes, mask)
     bytes.size shouldBe mask.sumBy { it.second }
 
@@ -82,10 +86,11 @@ fun <T : Any> checkedSerialize(
 fun <T : Any> roundTrip(
     value: T,
     serializers: SerializersModule = EmptySerializersModule,
-    strategy: KSerializer<T>? = null
+    strategy: KSerializer<T>? = null,
+    outerFixedLength: IntArray = IntArray(0)
 ) {
-    val serialization = serialize(value, strategy, serializersModule = BFLSerializers + serializers)
-    val deserialization = deserialize(serialization, value::class, strategy, BFLSerializers + serializers)
+    val serialization = serialize(value, strategy, serializersModule = BFLSerializers + serializers, outerFixedLength = outerFixedLength)
+    val deserialization = deserialize(serialization, value::class, strategy, BFLSerializers + serializers, outerFixedLength = outerFixedLength)
 
     deserialization shouldBe value
 }
@@ -97,12 +102,13 @@ fun <T : Any> sameSize(
     value1: T,
     value2: T,
     serializers: SerializersModule = EmptySerializersModule,
-    strategy: KSerializer<T>? = null
+    strategy: KSerializer<T>? = null,
+    outerFixedLength: IntArray = IntArray(0)
 ) {
     value1 shouldNotBe value2
 
-    val serialization1 = serialize(value1, strategy, serializersModule = BFLSerializers + serializers)
-    val serialization2 = serialize(value2, strategy, serializersModule = BFLSerializers + serializers)
+    val serialization1 = serialize(value1, strategy, serializersModule = BFLSerializers + serializers, outerFixedLength = outerFixedLength)
+    val serialization2 = serialize(value2, strategy, serializersModule = BFLSerializers + serializers, outerFixedLength = outerFixedLength)
 
     serialization1 shouldNotBe serialization2
     serialization1.size shouldBe serialization2.size

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/exceptions/MissingSerializersTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/exceptions/MissingSerializersTest.kt
@@ -50,24 +50,6 @@ class MissingSerializersTest {
         }
     }
 
-    @Test
-    fun `direct serialization of primitive values should fail`() {
-        listOf(
-            true,
-            1.toByte(),
-            1,
-            1L,
-            'a',
-            0.1,
-            0.1F,
-            "a"
-        ).forEach {
-            assertThrows<NoSuchElementException> {
-                serialize(it)
-            }
-        }
-    }
-
     @Serializable
     open class Dummy
 

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/builtin/ListSerializableTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/builtin/ListSerializableTest.kt
@@ -1,0 +1,33 @@
+package com.ing.serialization.bfl.serde.serializers.builtin
+
+import com.ing.serialization.bfl.serde.roundTripInlined
+import com.ing.serialization.bfl.serde.sameSizeInlined
+import kotlinx.serialization.Serializable
+import org.junit.jupiter.api.Test
+
+class ListSerializableTest {
+    @Test
+    fun `List with primitive should be serialized directly`() {
+        val list = listOf(1)
+
+        roundTripInlined(list, outerFixedLength = intArrayOf(2))
+        // roundTrip will fail because of type information loss,
+        // see comments in Api.kt
+
+        sameSizeInlined(listOf(1, 2), listOf(1), outerFixedLength = intArrayOf(2))
+    }
+
+    @Serializable
+    data class Data(val int: Int = 2)
+
+    @Test
+    fun `List with serializable class should be serialized directly`() {
+        val list = listOf(Data())
+
+        roundTripInlined(list, outerFixedLength = intArrayOf(2))
+        // roundTrip will fail because of type information loss,
+        // see comments in Api.kt
+
+        sameSizeInlined(listOf(Data(1)), listOf(Data(1), Data(2)), outerFixedLength = intArrayOf(2))
+    }
+}

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/builtin/PrimitiveTypesTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/builtin/PrimitiveTypesTest.kt
@@ -1,0 +1,40 @@
+package com.ing.serialization.bfl.serde.serializers.builtin
+
+import com.ing.serialization.bfl.serde.roundTrip
+import com.ing.serialization.bfl.serde.roundTripInlined
+import com.ing.serialization.bfl.serde.sameSizeInlined
+import org.junit.jupiter.api.Test
+
+class PrimitiveTypesTest {
+    inline fun <reified T : Any> testPrimitive(value: T) {
+        roundTripInlined(value, outerFixedLength = intArrayOf(5))
+        roundTrip(value, outerFixedLength = intArrayOf(5))
+    }
+
+    @Test
+    fun `direct serialization of primitive values should succeed`() {
+        testPrimitive(true)
+        testPrimitive(1.toByte())
+        testPrimitive(1)
+        testPrimitive(1L)
+        testPrimitive('a')
+    }
+
+    @Test
+    fun `direct serialization of floating point values should succeed`() {
+        roundTripInlined(1.0F, outerFixedLength = intArrayOf(5, 5))
+        roundTrip(1.0F, outerFixedLength = intArrayOf(5, 5))
+        roundTripInlined(4.33, outerFixedLength = intArrayOf(5, 5))
+        roundTrip(4.33, outerFixedLength = intArrayOf(5, 5))
+    }
+
+    @Test
+    fun `direct serialization of a string should succeed`() {
+        val string = "Test"
+        roundTripInlined(string, outerFixedLength = intArrayOf(5))
+        roundTrip(string, outerFixedLength = intArrayOf(5))
+
+        val other = "What"
+        sameSizeInlined(string, other, outerFixedLength = intArrayOf(5))
+    }
+}


### PR DESCRIPTION
Allow top-level serialization of non-structure types and collections.
If a collection is passed to the top-level serialize/deserialize call, the respective function expects `outerFixedLength` parameter which works the same way as `@FixedLength`.