### PR TITLE
Accept Class<T> instead of Klass<T> for deserialization.

### DIFF
--- a/src/main/kotlin/com/ing/serialization/bfl/serde/SerdeError.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/SerdeError.kt
@@ -37,7 +37,7 @@ sealed class SerdeError : IllegalStateException {
         SerdeError("Serializers module has no serializers for a context type ${descriptor.serialName}")
 
     class NoTopLevelSerializer : SerdeError {
-        constructor(klass: KClass<*>) : super("Top-level serializer absent for ${klass.simpleName}")
+        constructor(clazz: Class<*>) : super("Top-level serializer absent for ${clazz.simpleName}")
         constructor(klass: KClass<*>, cause: Throwable) : super("Top-level serializer absent for ${klass.simpleName}", cause)
     }
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/Tests.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/Tests.kt
@@ -90,7 +90,7 @@ fun <T : Any> roundTrip(
     outerFixedLength: IntArray = IntArray(0)
 ) {
     val serialization = serialize(value, strategy, serializersModule = BFLSerializers + serializers, outerFixedLength = outerFixedLength)
-    val deserialization = deserialize(serialization, value::class, strategy, BFLSerializers + serializers, outerFixedLength = outerFixedLength)
+    val deserialization = deserialize(serialization, value::class.java, strategy, BFLSerializers + serializers, outerFixedLength = outerFixedLength)
 
     deserialization shouldBe value
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/exceptions/MissingSerializersTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/exceptions/MissingSerializersTest.kt
@@ -46,7 +46,7 @@ class MissingSerializersTest {
         }
 
         assertThrows<SerdeError.NoTopLevelSerializer> {
-            deserialize(byteArrayOf(), Data::class)
+            deserialize(byteArrayOf(), Data::class.java)
         }
     }
 


### PR DESCRIPTION
Improve compatibility for ol' plain Java.