### PR TITLE
Polymorphics/dynamic serial name length

### DIFF
--- a/src/main/kotlin/com/ing/serialization/bfl/serde/SerdeError.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/SerdeError.kt
@@ -33,6 +33,9 @@ sealed class SerdeError : IllegalStateException {
     class NoPolymorphicSerializers(descriptor: SerialDescriptor) :
         SerdeError("Serializers module has no serializers for a polymorphic type ${descriptor.serialName}")
 
+    class VariablePolymorphicSerialName(descriptor: SerialDescriptor) :
+        SerdeError("Variants of ${descriptor.serialName} have differently sized serial names")
+
     class NoContextualSerializer(descriptor: SerialDescriptor) :
         SerdeError("Serializers module has no serializers for a context type ${descriptor.serialName}")
 

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/exceptions/VariablePolymorphicSerialNameTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/exceptions/VariablePolymorphicSerialNameTest.kt
@@ -1,0 +1,61 @@
+package com.ing.serialization.bfl.serde.exceptions
+
+import com.ing.serialization.bfl.api.Surrogate
+import com.ing.serialization.bfl.api.SurrogateSerializer
+import com.ing.serialization.bfl.api.serialize
+import com.ing.serialization.bfl.serde.SerdeError
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import com.ing.serialization.bfl.api.reified.serialize as inlinedSerialize
+
+class VariablePolymorphicSerialNameTest {
+    @Serializable
+    data class Transport(val plane: Plane)
+
+    @Test
+    fun `serialization of variants with serialName's  with different lengths should fail`() {
+        val serializersModule = SerializersModule {
+            polymorphic(Plane::class) {
+                subclass(Airbus::class, AirbusSerializer)
+                subclass(Boeing::class, BoeingSerializer)
+            }
+        }
+
+        assertThrows<SerdeError.VariablePolymorphicSerialName> {
+            serialize(Transport(Airbus()), serializersModule = serializersModule)
+        }
+
+        assertThrows<SerdeError.VariablePolymorphicSerialName> {
+            inlinedSerialize(Transport(Airbus()), serializersModule = serializersModule)
+        }
+    }
+}
+
+// Treat them as 3rd party instances.
+interface Plane
+data class Airbus(val model: Int = 380) : Plane
+data class Boeing(val model: Int = 787) : Plane
+// <-- 3rd party.
+
+object AirbusSerializer : KSerializer<Airbus>
+by (SurrogateSerializer(AirbusSurrogate.serializer()) { AirbusSurrogate(it.model) })
+
+object BoeingSerializer : KSerializer<Boeing>
+by (SurrogateSerializer(BoeingSurrogate.serializer()) { BoeingSurrogate(it.model) })
+
+@Serializable
+@SerialName("0")
+data class AirbusSurrogate(val model: Int) : Surrogate<Airbus> {
+    override fun toOriginal() = Airbus(model)
+}
+
+@Serializable
+@SerialName("00")
+data class BoeingSurrogate(val model: Int) : Surrogate<Boeing> {
+    override fun toOriginal() = Boeing(model)
+}

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/ClassPolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/ClassPolymorphicTest.kt
@@ -2,13 +2,13 @@ package com.ing.serialization.bfl.serde.serializers.custom.polymorphic
 
 import com.ing.serialization.bfl.serde.checkedSerialize
 import com.ing.serialization.bfl.serde.checkedSerializeInlined
-import com.ing.serialization.bfl.serde.element.ElementFactory
 import com.ing.serialization.bfl.serde.generateRSAPubKey
 import com.ing.serialization.bfl.serde.roundTrip
 import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.polymorphic
 import org.junit.jupiter.api.Test
 import java.security.PublicKey
 
@@ -20,7 +20,7 @@ class ClassPolymorphicTest {
     @Test
     fun `Polymorphic type within structure should be serialized successfully`() {
         val mask = listOf(
-            Pair("pk.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("pk.serialName", PublicKeyBaseSurrogate.SERIAL_NAME_LENGTH),
             Pair("pk.value", 4 + PublicKeyBaseSurrogate.ENCODED_SIZE)
         )
 

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/ListPolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/ListPolymorphicTest.kt
@@ -5,7 +5,6 @@ import com.ing.serialization.bfl.api.serialize
 import com.ing.serialization.bfl.serde.SerdeError
 import com.ing.serialization.bfl.serde.checkedSerialize
 import com.ing.serialization.bfl.serde.checkedSerializeInlined
-import com.ing.serialization.bfl.serde.element.ElementFactory
 import com.ing.serialization.bfl.serde.generateRSAPubKey
 import com.ing.serialization.bfl.serde.roundTrip
 import com.ing.serialization.bfl.serde.roundTripInlined
@@ -26,10 +25,10 @@ class ListPolymorphicTest {
     fun `List of polymorphic type should be serialized successfully`() {
         val mask = listOf(
             Pair("nested.length", 4),
-            Pair("nested[0].serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("nested[0].serialName", PublicKeyBaseSurrogate.SERIAL_NAME_LENGTH),
             Pair("nested[0].length", 4),
             Pair("nested[0].value", PublicKeyBaseSurrogate.ENCODED_SIZE),
-            Pair("nested[1].serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("nested[1].serialName", PublicKeyBaseSurrogate.SERIAL_NAME_LENGTH),
             Pair("nested[1].length", 4),
             Pair("nested[1].value", PublicKeyBaseSurrogate.ENCODED_SIZE)
         )

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/NestedClassesPolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/NestedClassesPolymorphicTest.kt
@@ -2,7 +2,6 @@ package com.ing.serialization.bfl.serde.serializers.custom.polymorphic
 
 import com.ing.serialization.bfl.serde.checkedSerialize
 import com.ing.serialization.bfl.serde.checkedSerializeInlined
-import com.ing.serialization.bfl.serde.element.ElementFactory
 import com.ing.serialization.bfl.serde.generateDSAPubKey
 import com.ing.serialization.bfl.serde.generateRSAPubKey
 import com.ing.serialization.bfl.serde.roundTrip
@@ -26,7 +25,7 @@ class NestedClassesPolymorphicTest {
         val data = Data(Some(generateRSAPubKey()))
 
         val mask = listOf(
-            Pair("some.pk.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("some.pk.serialName", PublicKeyBaseSurrogate.SERIAL_NAME_LENGTH),
             Pair("some.pk.length", 4),
             Pair("some.nested.value", PublicKeyBaseSurrogate.ENCODED_SIZE)
         )

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PolymorphicTest.kt
@@ -1,7 +1,6 @@
 package com.ing.serialization.bfl.serde.serializers.custom.polymorphic
 
 import com.ing.serialization.bfl.serde.checkedSerializeInlined
-import com.ing.serialization.bfl.serde.element.ElementFactory
 import com.ing.serialization.bfl.serde.generateRSAPubKey
 import com.ing.serialization.bfl.serde.roundTrip
 import com.ing.serialization.bfl.serde.roundTripInlined
@@ -18,7 +17,7 @@ class PolymorphicTest {
         println(data.encoded.joinToString(separator = ","))
 
         val mask = listOf(
-            Pair("serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("serialName", PublicKeyBaseSurrogate.SERIAL_NAME_LENGTH),
             Pair("length", 4),
             Pair("value", PublicKeyBaseSurrogate.ENCODED_SIZE)
         )

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PublicKeySerializers.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PublicKeySerializers.kt
@@ -4,6 +4,7 @@ import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.api.Surrogate
 import com.ing.serialization.bfl.api.SurrogateSerializer
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import sun.security.provider.DSAPublicKeyImpl
 import sun.security.rsa.RSAPublicKeyImpl
@@ -16,6 +17,7 @@ abstract class PublicKeyBaseSurrogate {
 
     companion object {
         const val ENCODED_SIZE = 900
+        const val SERIAL_NAME_LENGTH = 2 + 2 * 3
     }
 }
 
@@ -27,6 +29,7 @@ by (SurrogateSerializer(DSASurrogate.serializer()) { DSASurrogate(it.encoded) })
 
 @Suppress("ArrayInDataClass")
 @Serializable
+@SerialName("RSA")
 data class RSASurrogate(
     @FixedLength([ENCODED_SIZE])
     override val encoded: ByteArray
@@ -37,6 +40,7 @@ data class RSASurrogate(
 
 @Suppress("ArrayInDataClass")
 @Serializable
+@SerialName("DSA")
 data class DSASurrogate(
     @FixedLength([ENCODED_SIZE])
     override val encoded: ByteArray


### PR DESCRIPTION
Remove hard bound on the length of the serial name for polymorphic variants.
Allow variants to have any serial names but require them to all be of the same length.