### PR TITLE
Feature/handle polymorphic

### DIFF
--- a/src/main/kotlin/com/ing/serialization/bfl/api/Definitions.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/api/Definitions.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.encoding.Encoder
 
 open class SurrogateSerializer<T, S : Surrogate<T>>(
     private val strategy: KSerializer<S>,
-    private val toSurrogate: (T) -> S
+    val toSurrogate: (T) -> S
 ) : KSerializer<T> {
     override val descriptor: SerialDescriptor = strategy.descriptor
 

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/BinaryFixedLengthInputDecoder.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/BinaryFixedLengthInputDecoder.kt
@@ -51,7 +51,7 @@ class BinaryFixedLengthInputDecoder(
             .removeNext()
             .expect<CollectionElement>()
 
-        // Collection might have been padded.
+        // collection might have been padded.
         input.skipBytes(collection.padding)
     }
 

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/BinaryFixedLengthInputDecoder.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/BinaryFixedLengthInputDecoder.kt
@@ -2,9 +2,9 @@ package com.ing.serialization.bfl.serde
 
 import com.ing.serialization.bfl.serde.element.CollectionElement
 import com.ing.serialization.bfl.serde.element.EnumElement
+import com.ing.serialization.bfl.serde.element.PolymorphicStructureElement
 import com.ing.serialization.bfl.serde.element.PrimitiveElement
 import com.ing.serialization.bfl.serde.element.StringElement
-import com.ing.serialization.bfl.serde.element.StructureElement
 import com.ing.serialization.bfl.serializers.BFLSerializers
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -82,7 +82,7 @@ class BinaryFixedLengthInputDecoder(
 
     override fun decodeNull(): Nothing? {
         structureProcessor.removeNext().let {
-            if (it.isPolymorphic) it.expect<StructureElement>().decodeNullPolymorphic(input, serializersModule)
+            if (it is PolymorphicStructureElement) it.decodeNull(input, serializersModule)
             else it.decodeNull(input)
         }
         return null
@@ -91,7 +91,7 @@ class BinaryFixedLengthInputDecoder(
     override fun <T> decodeSerializableValue(deserializer: DeserializationStrategy<T>): T {
         if (!this::structureProcessor.isInitialized) {
             structureProcessor =
-                FixedLengthStructureProcessor(deserializer.descriptor, serializersModule, outerFixedLength)
+                FixedLengthStructureProcessor(deserializer.descriptor, serializersModule, outerFixedLength, phase = Phase.DECODING)
         }
         return super.decodeSerializableValue(deserializer)
     }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/BinaryFixedLengthInputDecoder.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/BinaryFixedLengthInputDecoder.kt
@@ -82,7 +82,7 @@ class BinaryFixedLengthInputDecoder(
 
     override fun decodeNull(): Nothing? {
         structureProcessor.removeNext().let {
-            if (it.isPolymorphic && it is StructureElement) it.decodeNullPolymorphic(input, serializersModule)
+            if (it.isPolymorphic) it.expect<StructureElement>().decodeNullPolymorphic(input, serializersModule)
             else it.decodeNull(input)
         }
         return null

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/BinaryFixedLengthInputDecoder.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/BinaryFixedLengthInputDecoder.kt
@@ -4,6 +4,7 @@ import com.ing.serialization.bfl.serde.element.CollectionElement
 import com.ing.serialization.bfl.serde.element.EnumElement
 import com.ing.serialization.bfl.serde.element.PrimitiveElement
 import com.ing.serialization.bfl.serde.element.StringElement
+import com.ing.serialization.bfl.serde.element.StructureElement
 import com.ing.serialization.bfl.serializers.BFLSerializers
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -80,7 +81,10 @@ class BinaryFixedLengthInputDecoder(
     override fun decodeNotNullMark() = input.readBoolean()
 
     override fun decodeNull(): Nothing? {
-        structureProcessor.removeNext().decodeNull(input)
+        structureProcessor.removeNext().let {
+            if (it.isPolymorphic && it is StructureElement) it.decodeNullPolymorphic(input, serializersModule)
+            else it.decodeNull(input)
+        }
         return null
     }
 

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/BinaryFixedLengthOutputEncoder.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/BinaryFixedLengthOutputEncoder.kt
@@ -63,7 +63,9 @@ class BinaryFixedLengthOutputEncoder(
 
     override fun encodeNull() {
         output.writeBoolean(false)
-        structureProcessor.removeNext().encodeNull(output)
+        // before encoding a null value, we need to know whether it was fully resolved during parsing (case of nullable
+        // polymorphic elements within the structure) - if not, an exception is thrown
+        structureProcessor.removeNext().verifyResolvabilityOrThrow().encodeNull(output)
     }
 
     override fun encodeNotNullMark() = output.writeBoolean(true)
@@ -71,7 +73,7 @@ class BinaryFixedLengthOutputEncoder(
     override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
         if (!this::structureProcessor.isInitialized) {
             structureProcessor =
-                FixedLengthStructureProcessor(serializer.descriptor, serializersModule, outerFixedLength)
+                FixedLengthStructureProcessor(serializer.descriptor, serializersModule, outerFixedLength, value, Phase.ENCODING)
         }
         super.encodeSerializableValue(serializer, value)
     }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/BinaryFixedLengthOutputEncoder.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/BinaryFixedLengthOutputEncoder.kt
@@ -73,7 +73,7 @@ class BinaryFixedLengthOutputEncoder(
     override fun <T> encodeSerializableValue(serializer: SerializationStrategy<T>, value: T) {
         if (!this::structureProcessor.isInitialized) {
             structureProcessor =
-                FixedLengthStructureProcessor(serializer.descriptor, serializersModule, outerFixedLength, value, Phase.ENCODING)
+                FixedLengthStructureProcessor(serializer.descriptor, serializersModule, outerFixedLength, value, phase = Phase.ENCODING)
         }
         super.encodeSerializableValue(serializer, value)
     }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/FixedLengthStructureProcessor.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/FixedLengthStructureProcessor.kt
@@ -40,14 +40,7 @@ class FixedLengthStructureProcessor(
         val parent = schedulable.parent
         if (parent != null && parent.isPolymorphic && phase == Phase.DECODING) {
             // populate the placeholder StructureElement
-            schedulable = ElementFactory(serializersModule).parse(descriptor, schedulable.propertyName)
-                .expect<StructureElement>()
-                .also {
-                    // update the parent with the newly created child
-                    val ind = parent.inner.indexOfFirst { element -> element is StructureElement }
-                    parent.inner[ind] = it
-                }
-            schedulable.parent = parent
+            schedulable = parent.resolvePolymorphicChild(descriptor, schedulable.propertyName, serializersModule)
             // remove the placeholder StructureElement from queue and add the populated version
             removeNext()
             queue.prepend(schedulable)

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/FixedLengthStructureProcessor.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/FixedLengthStructureProcessor.kt
@@ -42,12 +42,10 @@ class FixedLengthStructureProcessor(
         if (phase == Phase.DECODING && parent != null && parent is PolymorphicStructureElement) {
             // populate the placeholder StructureElement
             schedulable = parent.resolvePolymorphicChild(descriptor, schedulable.propertyName, serializersModule)
-            // replace the placeholder StructureElement from queue with the populated version
-            removeNext()
-            queue.prepend(schedulable)
+            queue.reschedule(schedulable)
         }
 
-        // Unwind structure's inner elements to the queue.
+        // unwind structure's inner elements to the queue.
         queue.prepend(schedulable.inner)
     }
 

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/FixedLengthStructureProcessor.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/FixedLengthStructureProcessor.kt
@@ -9,11 +9,12 @@ import kotlinx.serialization.modules.SerializersModule
 
 class FixedLengthStructureProcessor(
     descriptor: SerialDescriptor,
-    serializersModule: SerializersModule,
-    outerFixedLength: IntArray = IntArray(0)
+    val serializersModule: SerializersModule,
+    outerFixedLength: IntArray = IntArray(0),
+    data: Any? = null,
+    private val phase: Phase = Phase.DECODING
 ) {
-
-    internal var structure: Element = ElementFactory(serializersModule, outerFixedLength).parse(descriptor)
+    internal var structure: Element = ElementFactory(serializersModule, outerFixedLength).parse(descriptor, data = data)
     private val queue = ArrayDeque<Element>()
 
     init {
@@ -33,7 +34,24 @@ class FixedLengthStructureProcessor(
      */
     fun beginStructure(descriptor: SerialDescriptor) {
         // TODO: add check if the struct on the stack coincides with the current descriptor.
-        val schedulable = queue.first().expect<StructureElement>()
+        var schedulable = queue.first().expect<StructureElement>()
+
+        // during decoding we need to populate the inner placeholder StructureElement of a polymorphic
+        val parent = schedulable.parent
+        if (parent != null && parent.isPolymorphic && phase == Phase.DECODING) {
+            // populate the placeholder StructureElement
+            schedulable = ElementFactory(serializersModule).parse(descriptor, schedulable.propertyName)
+                .expect<StructureElement>()
+                .also {
+                    // update the parent with the newly created child
+                    val ind = parent.inner.indexOfFirst { element -> element is StructureElement }
+                    parent.inner[ind] = it
+                }
+            schedulable.parent = parent
+            // remove the placeholder StructureElement from queue and add the populated version
+            removeNext()
+            queue.prepend(schedulable)
+        }
 
         // Unwind structure's inner elements to the queue.
         queue.prepend(schedulable.inner)
@@ -50,6 +68,11 @@ class FixedLengthStructureProcessor(
     fun beginCollection(collectionSize: Int) {
         val collection = queue.first().expect<CollectionElement>()
         collection.actualLength = collectionSize
+
+        // if an empty list containing nullable polymorphic has not been fully resolved in the parsing stage an exception is thrown
+        if (collectionSize == 0 && phase == Phase.ENCODING) {
+            collection.verifyResolvabilityOrThrow()
+        }
 
         repeat(collectionSize) {
             queue.prepend(collection.inner)

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/Phase.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/Phase.kt
@@ -1,0 +1,5 @@
+package com.ing.serialization.bfl.serde
+
+enum class Phase {
+    ENCODING, DECODING
+}

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/SerdeError.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/SerdeError.kt
@@ -33,9 +33,9 @@ sealed class SerdeError : IllegalStateException {
     class DifferentPolymorphicImplementations(serialName: String) :
         SerdeError("Different implementations of the same base type '$serialName' are not allowed")
 
-    class NoPolymorphicSerializerForSubClass(type: String) : SerdeError("Serializer for '$type' cannot be found")
+    class NoPolymorphicSerializerForSubClass(type: String) : SerdeError("Serializer absent for polymorphic subclass $type")
 
-    class NoSurrogateSerializerForPolymorphic(type: String) : SerdeError("Surrogate serializer for polymorphic class '$type' cannot be found")
+    class NoSurrogateSerializer(klass: KClass<*>) : SerdeError("Surrogate serializer absent for $klass")
 
     class NoPolymorphicBaseClass(serialName: String) : SerdeError("Base class for '$serialName' cannot be found")
 

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/SerdeError.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/SerdeError.kt
@@ -30,6 +30,13 @@ sealed class SerdeError : IllegalStateException {
                 "Please verify that all collections and strings in that chain are sufficiently annotated"
         )
 
+    class DifferentPolymorphicImplementations(serialName: String) :
+        SerdeError("Different implementations of the same base type '$serialName' are not allowed")
+
+    class UnknownPolymorphic(type: String) : SerdeError("Polymorphic class '$type' cannot be found")
+
+    class NonResolvablePolymorphic(serialName: String) : SerdeError("Implementation of '$serialName' cannot be inferred")
+
     class NoPolymorphicSerializers(descriptor: SerialDescriptor) :
         SerdeError("Serializers module has no serializers for a polymorphic type ${descriptor.serialName}")
 

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/SerdeError.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/SerdeError.kt
@@ -33,7 +33,11 @@ sealed class SerdeError : IllegalStateException {
     class DifferentPolymorphicImplementations(serialName: String) :
         SerdeError("Different implementations of the same base type '$serialName' are not allowed")
 
-    class UnknownPolymorphic(type: String) : SerdeError("Polymorphic class '$type' cannot be found")
+    class NoPolymorphicSerializerForSubClass(type: String) : SerdeError("Serializer for '$type' cannot be found")
+
+    class NoSurrogateSerializerForPolymorphic(type: String) : SerdeError("Surrogate serializer for polymorphic class '$type' cannot be found")
+
+    class NoPolymorphicBaseClass(serialName: String) : SerdeError("Base class for '$serialName' cannot be found")
 
     class NonResolvablePolymorphic(serialName: String) : SerdeError("Implementation of '$serialName' cannot be inferred")
 

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/Utils.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/Utils.kt
@@ -1,5 +1,15 @@
 package com.ing.serialization.bfl.serde
 
+import com.ing.serialization.bfl.serde.element.CollectionElement
+import com.ing.serialization.bfl.serde.element.Element
+import com.ing.serialization.bfl.serde.element.EnumElement
+import com.ing.serialization.bfl.serde.element.PrimitiveElement
+import com.ing.serialization.bfl.serde.element.StringElement
+import com.ing.serialization.bfl.serde.element.StructureElement
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
 fun <T> ArrayDeque<T>.prepend(value: T) {
     addFirst(value)
 }
@@ -7,3 +17,119 @@ fun <T> ArrayDeque<T>.prepend(value: T) {
 fun <T> ArrayDeque<T>.prepend(list: List<T>) {
     addAll(0, list)
 }
+
+/**
+ * Extension function that attempts to parse any iterable data structure as a list using reflection
+ * Throws an exception if the data structure is of none of the supported types
+ *
+ * @throws IllegalStateException when the actual type of the data structure is none of the supported
+ */
+@Suppress("ComplexMethod")
+fun <T> T.convertToList() = when (this) {
+    is Collection<*> -> this.toList()
+    is MutableCollection<*> -> this.toList()
+    is Map<*, *> -> this.toList()
+    is MutableMap<*, *> -> this.toList()
+    is Array<*> -> this.toList()
+    is ByteArray -> this.toList()
+    is CharArray -> this.toList()
+    is ShortArray -> this.toList()
+    is IntArray -> this.toList()
+    is LongArray -> this.toList()
+    is DoubleArray -> this.toList()
+    is FloatArray -> this.toList()
+    is BooleanArray -> this.toList()
+    else -> error("Unknown iterable type - Cannot convert to list!")
+}
+
+/**
+ * Extension function that retrieves the name and value of a specific property from a data structure
+ * @param descriptor serial descriptor of the data object
+ * @param index index of the property within the structure of the data object
+ */
+fun <T> T.getPropertyNameValuePair(descriptor: SerialDescriptor, index: Int): Pair<String, Any?> {
+    val propertyName = descriptor.getElementName(index)
+    // Class.forName(descriptor.serialName).getConstructor(this!!::class.java).newInstance(this)
+    val propertyValue = this?.let {
+        it::class.memberProperties
+            // this search is based on the assumption that surrogates use serial names for their properties same to the
+            // actual names of the properties
+            .firstOrNull { property -> property.name == propertyName }
+            ?.also { property -> property.isAccessible = true } // in case some property is private or protected
+            ?.call(it)
+    }
+    return Pair(propertyName, propertyValue)
+}
+
+/**
+ * Extension function that merges an element with another element of the same type (externally respected condition)
+ * Used for merging the children of a CollectionElement into one single Element type.
+ *
+ * @param other the element to be merged with
+ * @throws IllegalArgumentException when the elements to be merged are not of the same type
+ * @throws IllegalStateException when an unknown element type is encountered (should be unreachable)
+ */
+fun Element.merge(other: Element): Element = when (this) {
+    is PrimitiveElement -> {
+        require(other is PrimitiveElement) { "Elements to be merged should be of the same type" }
+        this.clone()
+    }
+    is EnumElement -> {
+        require(other is EnumElement) { "Elements to be merged should be of the same type" }
+        this.clone()
+    }
+    is StringElement -> {
+        require(other is StringElement) { "Elements to be merged should be of the same type" }
+        this.clone()
+    }
+    is StructureElement -> {
+        require(other is StructureElement) { "Elements to be merged should be of the same type" }
+        this.mergeWithChildren(other)
+    }
+    is CollectionElement -> {
+        require(other is CollectionElement) { "Elements to be merged should be of the same type" }
+        this.mergeWithChildren(other)
+    }
+    else -> error("Unknown implementation of Element")
+}
+
+/**
+ * Extension function supporting some special handling for merging 2 StructureElements
+ *
+ * @param other the StructureElement to be merged with
+ * @throws IllegalStateException when different implementations of the same base type are encountered
+ */
+fun StructureElement.mergeWithChildren(other: StructureElement): StructureElement =
+    if (isNull || other.isNull) {
+        if (isNull) other.clone() else this.clone()
+    } else {
+        // Polymorphic type consists of a string describing type and a structure
+        if (isPolymorphic && inner.last().serialName != other.inner.last().serialName) {
+            error("Different implementations of the same base type are not allowed")
+        }
+
+        inner = inner.mapIndexed { idx, child -> child.merge(other.inner[idx]) }.toMutableList()
+
+        StructureElement(serialName, propertyName, inner, isNullable).also {
+            it.isPolymorphic = isPolymorphic
+            it.isNull = isNull
+            it.assignParentToChildren()
+        }
+    }
+
+/**
+ * Extension function supporting some special handling for merging 2 CollectionElements
+ *
+ * @param other the CollectionElement to be merged with
+ */
+fun CollectionElement.mergeWithChildren(other: CollectionElement): CollectionElement =
+    if (isNull || other.isNull) {
+        if (isNull) other.clone() else this.clone()
+    } else {
+        inner = inner.mapIndexed { idx, child -> child.merge(other.inner[idx]) }.toMutableList()
+
+        CollectionElement(serialName, propertyName, inner, actualLength, requiredLength, isNullable).also {
+            it.isNull = isNull
+            it.assignParentToChildren()
+        }
+    }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/CollectionElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/CollectionElement.kt
@@ -16,6 +16,10 @@ class CollectionElement(
     val requiredLength: Int,
     override var isNullable: Boolean
 ) : Element(serialName, propertyName, inner) {
+    init {
+        inner.forEach { it.parent = this }
+    }
+
     /**
      * INT (collection length) + number_of_elements * sum_i { size(inner_i) }
      * = 4 + n * sum_i { size(inner_i) }
@@ -59,13 +63,8 @@ class CollectionElement(
         repeat(requiredLength) { inner.forEach { it.decodeNull(input) } }
     }
 
-    fun assignParentToChildren() {
-        inner.forEach { it.parent = this }
-    }
-
     override fun clone(): CollectionElement =
         CollectionElement(serialName, propertyName, inner, actualLength, requiredLength, isNullable).also {
             it.isNull = isNull
-            it.assignParentToChildren()
         }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/CollectionElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/CollectionElement.kt
@@ -1,6 +1,7 @@
 package com.ing.serialization.bfl.serde.element
 
 import com.ing.serialization.bfl.serde.SerdeError
+import java.io.DataInput
 import java.io.DataOutput
 
 /**
@@ -10,7 +11,7 @@ import java.io.DataOutput
 class CollectionElement(
     serialName: String,
     propertyName: String,
-    inner: List<Element>,
+    inner: MutableList<Element>,
     var actualLength: Int? = null,
     val requiredLength: Int,
     override var isNullable: Boolean
@@ -48,6 +49,23 @@ class CollectionElement(
             return elementSize * (requiredLength - actualLength)
         }
 
-    override fun encodeNull(output: DataOutput) =
-        repeat(4 + requiredLength * elementSize) { output.writeByte(0) }
+    override fun encodeNull(output: DataOutput) {
+        repeat(4) { output.writeByte(0) }
+        repeat(requiredLength) { inner.forEach { it.encodeNull(output) } }
+    }
+
+    override fun decodeNull(input: DataInput) {
+        input.skipBytes(4)
+        repeat(requiredLength) { inner.forEach { it.decodeNull(input) } }
+    }
+
+    fun assignParentToChildren() {
+        inner.forEach { it.parent = this }
+    }
+
+    override fun clone(): CollectionElement =
+        CollectionElement(serialName, propertyName, inner, actualLength, requiredLength, isNullable).also {
+            it.isNull = isNull
+            it.assignParentToChildren()
+        }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/Element.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/Element.kt
@@ -11,7 +11,6 @@ import java.io.DataOutput
 abstract class Element(val serialName: String, val propertyName: String, var inner: MutableList<Element> = mutableListOf()) {
     abstract var isNullable: Boolean
     var parent: Element? = null
-    var isPolymorphic: Boolean = false
     var isNull: Boolean = false
 
     protected abstract val inherentLayout: List<Pair<String, Int>>
@@ -46,12 +45,13 @@ abstract class Element(val serialName: String, val propertyName: String, var inn
         return this
     }
 
+    open fun verifySelfResolvabilityOrThrow() = Unit
+
     fun verifyResolvabilityOrThrow(): Element {
-        // if a null polymorphic has not been resolved in the parsing stage, an exception is thrown
-        if (isNull && isPolymorphic) {
-            throw SerdeError.NonResolvablePolymorphic(serialName)
-        }
-        // check also the children of the element for resolvability
+        // first verify resolvability of the element itself
+        verifySelfResolvabilityOrThrow()
+
+        // then check also the children of the element for resolvability
         inner.forEach { it.verifyResolvabilityOrThrow() }
         return this
     }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/Element.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/Element.kt
@@ -49,7 +49,7 @@ abstract class Element(val serialName: String, val propertyName: String, var inn
     fun verifyResolvabilityOrThrow(): Element {
         // if a null polymorphic has not been resolved in the parsing stage, an exception is thrown
         if (isNull && isPolymorphic) {
-            error("Implementation of '$serialName' cannot be inferred")
+            throw SerdeError.NonResolvablePolymorphic(serialName)
         }
         // check also the children of the element for resolvability
         inner.forEach { it.verifyResolvabilityOrThrow() }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/EnumElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/EnumElement.kt
@@ -20,4 +20,6 @@ class EnumElement(
     override fun encodeNull(output: DataOutput) = encode(0, output)
 
     fun decode(stream: DataInput): Int = stream.readInt()
+
+    override fun clone(): EnumElement = EnumElement(serialName, propertyName, isNullable)
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/PolymorphicStructureElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/PolymorphicStructureElement.kt
@@ -1,0 +1,44 @@
+package com.ing.serialization.bfl.serde.element
+
+import com.ing.serialization.bfl.serde.SerdeError
+import com.ing.serialization.bfl.serde.resolvePolymorphicChild
+import kotlinx.serialization.modules.SerializersModule
+import java.io.DataInput
+import java.io.DataOutput
+import kotlin.reflect.KClass
+
+class PolymorphicStructureElement(
+    serialName: String,
+    propertyName: String,
+    inner: MutableList<Element>,
+    isNullable: Boolean
+) : StructureElement(serialName, propertyName, inner, isNullable) {
+    var baseClass: KClass<in Any>? = null
+
+    override fun encodeNull(output: DataOutput) {
+        val type = inner.first().expect<StringElement>()
+        val value = inner.last().expect<StructureElement>()
+        type.encode(value.serialName, output)
+        value.encodeNull(output)
+    }
+
+    fun decodeNull(input: DataInput, serializersModule: SerializersModule) {
+        val type = inner.first().expect<StringElement>().decode(input)
+        val placeholderValue = inner.last().expect<StructureElement>()
+        val descriptor = serializersModule.getPolymorphic(
+            baseClass = requireNotNull(baseClass) { "Something went wrong - Base class of polymorphic StructureElement should have been set" },
+            serializedClassName = type
+        )?.descriptor ?: throw SerdeError.NoPolymorphicSerializerForSubClass(type)
+        val newValue = this.resolvePolymorphicChild(descriptor, placeholderValue.propertyName, serializersModule)
+        newValue.decodeNull(input)
+    }
+
+    override fun verifySelfResolvabilityOrThrow() {
+        // if a null polymorphic has not been resolved in the parsing stage, an exception is thrown
+        isNull && throw SerdeError.NonResolvablePolymorphic(serialName)
+    }
+
+    override fun clone(): PolymorphicStructureElement = PolymorphicStructureElement(serialName, propertyName, inner, isNullable).also {
+        it.isNull = isNull
+    }
+}

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/PrimitiveElement.kt
@@ -18,7 +18,7 @@ import java.io.DataOutput
 class PrimitiveElement(
     serialName: String,
     propertyName: String,
-    private val kind: SerialKind,
+    val kind: SerialKind,
     override var isNullable: Boolean
 ) : Element(serialName, propertyName) {
     init {
@@ -108,4 +108,6 @@ class PrimitiveElement(
         input.readFully(surrogateInput)
         return deserialize<DoubleSurrogate>(surrogateInput).toOriginal()
     }
+
+    override fun clone(): PrimitiveElement = PrimitiveElement(serialName, propertyName, kind, isNullable)
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/StringElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/StringElement.kt
@@ -56,4 +56,6 @@ class StringElement(
 
         return string
     }
+
+    override fun clone(): StringElement = StringElement(serialName, propertyName, requiredLength, isNullable)
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/StructureElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/StructureElement.kt
@@ -1,13 +1,9 @@
 package com.ing.serialization.bfl.serde.element
 
-import com.ing.serialization.bfl.serde.SerdeError
-import com.ing.serialization.bfl.serde.resolvePolymorphicChild
-import kotlinx.serialization.modules.SerializersModule
 import java.io.DataInput
 import java.io.DataOutput
-import kotlin.reflect.KClass
 
-class StructureElement(
+open class StructureElement(
     serialName: String,
     propertyName: String,
     inner: MutableList<Element>,
@@ -16,8 +12,6 @@ class StructureElement(
     init {
         inner.forEach { it.parent = this }
     }
-    // set only in polymorphic StructureElements
-    var baseClass: KClass<in Any>? = null
 
     override val inherentLayout by lazy {
         listOf(
@@ -30,33 +24,14 @@ class StructureElement(
     }
 
     override fun encodeNull(output: DataOutput) {
-        if (isPolymorphic) {
-            val type = inner.first().expect<StringElement>()
-            val value = inner.last().expect<StructureElement>()
-            type.encode(value.serialName, output)
-            value.encodeNull(output)
-        } else {
-            inner.forEach { it.encodeNull(output) }
-        }
+        inner.forEach { it.encodeNull(output) }
     }
 
     override fun decodeNull(input: DataInput) {
         inner.forEach { it.decodeNull(input) }
     }
 
-    fun decodeNullPolymorphic(input: DataInput, serializersModule: SerializersModule) {
-        val type = inner.first().expect<StringElement>().decode(input)
-        val placeholderValue = inner.last().expect<StructureElement>()
-        val descriptor = serializersModule.getPolymorphic(
-            baseClass = requireNotNull(baseClass) { "Something went wrong - Base class of polymorphic StructureElement should have been set" },
-            serializedClassName = type
-        )?.descriptor ?: throw SerdeError.NoPolymorphicSerializerForSubClass(type)
-        val newValue = this.resolvePolymorphicChild(descriptor, placeholderValue.propertyName, serializersModule)
-        newValue.decodeNull(input)
-    }
-
     override fun clone(): StructureElement = StructureElement(serialName, propertyName, inner, isNullable).also {
-        it.isPolymorphic = isPolymorphic
         it.isNull = isNull
     }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/StructureElement.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/StructureElement.kt
@@ -1,20 +1,62 @@
 package com.ing.serialization.bfl.serde.element
 
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.serializer
+import java.io.DataInput
 import java.io.DataOutput
 
 class StructureElement(
     serialName: String,
     propertyName: String,
-    inner: List<Element>,
+    inner: MutableList<Element>,
     override var isNullable: Boolean
 ) : Element(serialName, propertyName, inner) {
     override val inherentLayout by lazy {
-        listOf(Pair("[Structure] length", constituentsSize))
+        listOf(
+            Pair("[Structure] length", constituentsSize),
+        )
     }
 
     private val constituentsSize by lazy {
         inner.sumBy { it.size }
     }
 
-    override fun encodeNull(output: DataOutput) = repeat(constituentsSize) { output.writeByte(0) }
+    override fun encodeNull(output: DataOutput) {
+        if (isPolymorphic) {
+            val type = inner.first().expect<StringElement>()
+            val value = inner.last().expect<StructureElement>()
+            type.encode(value.serialName, output)
+            value.encodeNull(output)
+        } else {
+            inner.forEach { it.encodeNull(output) }
+        }
+    }
+
+    override fun decodeNull(input: DataInput) {
+        inner.forEach { it.decodeNull(input) }
+    }
+
+    fun decodeNullPolymorphic(input: DataInput, serializersModule: SerializersModule) {
+        val type = inner.first().expect<StringElement>().decode(input)
+        val placeholderValue = inner.last().expect<StructureElement>()
+        val descriptor = serializersModule.serializer(Class.forName(type)).descriptor
+        val newValue = ElementFactory(serializersModule)
+            .parse(descriptor, placeholderValue.propertyName)
+            .expect<StructureElement>().also {
+                it.parent = this
+            }
+        val ind = inner.indexOfFirst { element -> element is StructureElement }
+        inner[ind] = newValue
+        newValue.decodeNull(input)
+    }
+
+    fun assignParentToChildren() {
+        inner.forEach { it.parent = this }
+    }
+
+    override fun clone(): StructureElement = StructureElement(serialName, propertyName, inner, isNullable).also {
+        it.isPolymorphic = isPolymorphic
+        it.isNull = isNull
+        it.assignParentToChildren()
+    }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/BigDecimalSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/BigDecimalSerializer.kt
@@ -2,13 +2,13 @@ package com.ing.serialization.bfl.serializers
 
 import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.api.SurrogateSerializer
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import java.math.BigDecimal
 
 typealias BigDecimalSizes = FixedLength
 
-object BigDecimalSerializer : KSerializer<BigDecimal> by (SurrogateSerializer(BigDecimalSurrogate.serializer()) { BigDecimalSurrogate.from(it) })
+object BigDecimalSerializer :
+    SurrogateSerializer<BigDecimal, BigDecimalSurrogate>(BigDecimalSurrogate.serializer(), { BigDecimalSurrogate.from(it) })
 
 @Suppress("ArrayInDataClass")
 @Serializable

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/CurrencySerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/CurrencySerializer.kt
@@ -3,11 +3,11 @@ package com.ing.serialization.bfl.serializers
 import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.api.Surrogate
 import com.ing.serialization.bfl.api.SurrogateSerializer
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import java.util.Currency
 
-object CurrencySerializer : KSerializer<Currency> by (SurrogateSerializer(CurrencySurrogate.serializer()) { CurrencySurrogate(it.currencyCode) })
+object CurrencySerializer :
+    SurrogateSerializer<Currency, CurrencySurrogate>(CurrencySurrogate.serializer(), { CurrencySurrogate(it.currencyCode) })
 
 @Serializable
 /**

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/CurrencySerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/CurrencySerializer.kt
@@ -19,6 +19,5 @@ data class CurrencySurrogate(@FixedLength([CURRENCY_SIZE]) val code: String) : S
 
     companion object {
         const val CURRENCY_SIZE = 3
-        fun from(currency: Currency): CurrencySurrogate = CurrencySurrogate(currency.currencyCode)
     }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/CurrencySerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/CurrencySerializer.kt
@@ -19,5 +19,6 @@ data class CurrencySurrogate(@FixedLength([CURRENCY_SIZE]) val code: String) : S
 
     companion object {
         const val CURRENCY_SIZE = 3
+        fun from(currency: Currency): CurrencySurrogate = CurrencySurrogate(currency.currencyCode)
     }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DateSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DateSerializer.kt
@@ -11,4 +11,8 @@ object DateSerializer : KSerializer<Date> by (SurrogateSerializer(DateSurrogate.
 @Serializable
 data class DateSurrogate(val l: Long) : Surrogate<Date> {
     override fun toOriginal(): Date = Date(l)
+
+    companion object {
+        fun from(date: Date): DateSurrogate = DateSurrogate(date.time)
+    }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DateSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DateSerializer.kt
@@ -11,8 +11,4 @@ object DateSerializer : KSerializer<Date> by (SurrogateSerializer(DateSurrogate.
 @Serializable
 data class DateSurrogate(val l: Long) : Surrogate<Date> {
     override fun toOriginal(): Date = Date(l)
-
-    companion object {
-        fun from(date: Date): DateSurrogate = DateSurrogate(date.time)
-    }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DateSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DateSerializer.kt
@@ -2,11 +2,10 @@ package com.ing.serialization.bfl.serializers
 
 import com.ing.serialization.bfl.api.Surrogate
 import com.ing.serialization.bfl.api.SurrogateSerializer
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import java.util.Date
 
-object DateSerializer : KSerializer<Date> by (SurrogateSerializer(DateSurrogate.serializer()) { DateSurrogate(it.time) })
+object DateSerializer : SurrogateSerializer<Date, DateSurrogate>(DateSurrogate.serializer(), { DateSurrogate(it.time) })
 
 @Serializable
 data class DateSurrogate(val l: Long) : Surrogate<Date> {

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DoubleSerializer.kt
@@ -2,10 +2,10 @@ package com.ing.serialization.bfl.serializers
 
 import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.api.SurrogateSerializer
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
-object DoubleSerializer : KSerializer<Double> by (SurrogateSerializer(DoubleSurrogate.serializer()) { DoubleSurrogate.from(it) })
+object DoubleSerializer :
+    SurrogateSerializer<Double, DoubleSurrogate>(DoubleSurrogate.serializer(), { DoubleSurrogate.from(it) })
 
 @Suppress("ArrayInDataClass")
 @Serializable

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DurationSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DurationSerializer.kt
@@ -14,8 +14,4 @@ data class DurationSurrogate(
     val nanos: Int
 ) : Surrogate<Duration> {
     override fun toOriginal(): Duration = Duration.ofSeconds(seconds, nanos.toLong())
-
-    companion object {
-        fun from(duration: Duration): DurationSurrogate = DurationSurrogate(duration.seconds, duration.nano)
-    }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DurationSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DurationSerializer.kt
@@ -2,11 +2,11 @@ package com.ing.serialization.bfl.serializers
 
 import com.ing.serialization.bfl.api.Surrogate
 import com.ing.serialization.bfl.api.SurrogateSerializer
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import java.time.Duration
 
-object DurationSerializer : KSerializer<Duration> by (SurrogateSerializer(DurationSurrogate.serializer()) { DurationSurrogate(it.seconds, it.nano) })
+object DurationSerializer :
+    SurrogateSerializer<Duration, DurationSurrogate>(DurationSurrogate.serializer(), { DurationSurrogate(it.seconds, it.nano) })
 
 @Serializable
 data class DurationSurrogate(

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/DurationSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/DurationSerializer.kt
@@ -14,4 +14,8 @@ data class DurationSurrogate(
     val nanos: Int
 ) : Surrogate<Duration> {
     override fun toOriginal(): Duration = Duration.ofSeconds(seconds, nanos.toLong())
+
+    companion object {
+        fun from(duration: Duration): DurationSurrogate = DurationSurrogate(duration.seconds, duration.nano)
+    }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/FloatSerializer.kt
@@ -2,10 +2,10 @@ package com.ing.serialization.bfl.serializers
 
 import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.api.SurrogateSerializer
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 
-object FloatSerializer : KSerializer<Float> by (SurrogateSerializer(FloatSurrogate.serializer()) { FloatSurrogate.from(it) })
+object FloatSerializer :
+    SurrogateSerializer<Float, FloatSurrogate>(FloatSurrogate.serializer(), { FloatSurrogate.from(it) })
 
 @Suppress("ArrayInDataClass")
 @Serializable

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/InstantSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/InstantSerializer.kt
@@ -2,11 +2,11 @@ package com.ing.serialization.bfl.serializers
 
 import com.ing.serialization.bfl.api.Surrogate
 import com.ing.serialization.bfl.api.SurrogateSerializer
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import java.time.Instant
 
-object InstantSerializer : KSerializer<Instant> by (SurrogateSerializer(InstantSurrogate.serializer()) { InstantSurrogate.from(it) })
+object InstantSerializer :
+    SurrogateSerializer<Instant, InstantSurrogate>(InstantSurrogate.serializer(), { InstantSurrogate.from(it) })
 
 @Serializable
 data class InstantSurrogate(

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/UUIDSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/UUIDSerializer.kt
@@ -14,8 +14,4 @@ data class UUIDSurrogate(
     val leastSigBits: Long
 ) : Surrogate<UUID> {
     override fun toOriginal(): UUID = UUID(mostSigBits, leastSigBits)
-
-    companion object {
-        fun from(uuid: UUID): UUIDSurrogate = UUIDSurrogate(uuid.mostSignificantBits, uuid.leastSignificantBits)
-    }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/UUIDSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/UUIDSerializer.kt
@@ -14,4 +14,8 @@ data class UUIDSurrogate(
     val leastSigBits: Long
 ) : Surrogate<UUID> {
     override fun toOriginal(): UUID = UUID(mostSigBits, leastSigBits)
+
+    companion object {
+        fun from(uuid: UUID): UUIDSurrogate = UUIDSurrogate(uuid.mostSignificantBits, uuid.leastSignificantBits)
+    }
 }

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/UUIDSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/UUIDSerializer.kt
@@ -2,11 +2,11 @@ package com.ing.serialization.bfl.serializers
 
 import com.ing.serialization.bfl.api.Surrogate
 import com.ing.serialization.bfl.api.SurrogateSerializer
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import java.util.UUID
 
-object UUIDSerializer : KSerializer<UUID> by (SurrogateSerializer(UUIDSurrogate.serializer()) { UUIDSurrogate(it.mostSignificantBits, it.leastSignificantBits) })
+object UUIDSerializer :
+    SurrogateSerializer<UUID, UUIDSurrogate>(UUIDSurrogate.serializer(), { UUIDSurrogate(it.mostSignificantBits, it.leastSignificantBits) })
 
 @Serializable
 data class UUIDSurrogate(

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/X500PrincipalSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/X500PrincipalSerializer.kt
@@ -3,7 +3,6 @@ package com.ing.serialization.bfl.serializers
 import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.api.Surrogate
 import com.ing.serialization.bfl.api.SurrogateSerializer
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import javax.security.auth.x500.X500Principal
 
@@ -21,9 +20,8 @@ data class X500PrincipalSurrogate(
          * sufficient for real-world use-cases.
          */
         const val PRINCIPAL_SIZE = 1024
-        fun from(x500Principal: X500Principal): X500PrincipalSurrogate = X500PrincipalSurrogate(x500Principal.name)
     }
 }
 
-object X500PrincipalSerializer : KSerializer<X500Principal>
-by (SurrogateSerializer(X500PrincipalSurrogate.serializer()) { X500PrincipalSurrogate(it.name) })
+object X500PrincipalSerializer :
+    SurrogateSerializer<X500Principal, X500PrincipalSurrogate>(X500PrincipalSurrogate.serializer(), { X500PrincipalSurrogate(it.name) })

--- a/src/main/kotlin/com/ing/serialization/bfl/serializers/X500PrincipalSerializer.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serializers/X500PrincipalSerializer.kt
@@ -21,6 +21,7 @@ data class X500PrincipalSurrogate(
          * sufficient for real-world use-cases.
          */
         const val PRINCIPAL_SIZE = 1024
+        fun from(x500Principal: X500Principal): X500PrincipalSurrogate = X500PrincipalSurrogate(x500Principal.name)
     }
 }
 

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/ElementTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/ElementTest.kt
@@ -120,7 +120,7 @@ class ElementTest {
             CollectionElement(
                 "",
                 "",
-                listOf(),
+                mutableListOf(),
                 null,
                 1,
                 false

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/exceptions/NoPolymorphicSerializerForSubClassTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/exceptions/NoPolymorphicSerializerForSubClassTest.kt
@@ -1,0 +1,47 @@
+package com.ing.serialization.bfl.serde.exceptions
+
+import com.ing.serialization.bfl.api.Surrogate
+import com.ing.serialization.bfl.api.SurrogateSerializer
+import com.ing.serialization.bfl.api.serialize
+import com.ing.serialization.bfl.serde.SerdeError
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+interface Base
+data class Registered(val value: Int) : Base
+data class UnRegistered(val value: Long) : Base
+
+object RegisteredSerializer :
+    SurrogateSerializer<Registered, RegisteredSurrogate>(RegisteredSurrogate.serializer(), { RegisteredSurrogate(it.value) })
+
+@Serializable
+@SerialName("SA")
+data class RegisteredSurrogate(
+    val value: Int
+) : Surrogate<Registered> {
+    override fun toOriginal() = Registered(value)
+}
+
+class NoPolymorphicSerializerForSubClassTest {
+    private val baseSerializers = SerializersModule {
+        polymorphic(Base::class) {
+            subclass(Registered::class, RegisteredSerializer)
+        }
+    }
+
+    @Serializable
+    data class Data(val myValue: Base)
+
+    @Test
+    fun `unregistered subclass of polymorphic type should throw an error`() {
+        val data = Data(UnRegistered(0))
+
+        assertThrows<SerdeError.NoPolymorphicSerializerForSubClass> {
+            serialize(data, serializersModule = baseSerializers)
+        }
+    }
+}

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/exceptions/NoSurrogateSerializerForPolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/exceptions/NoSurrogateSerializerForPolymorphicTest.kt
@@ -1,0 +1,47 @@
+package com.ing.serialization.bfl.serde.exceptions
+
+import com.ing.serialization.bfl.api.Surrogate
+import com.ing.serialization.bfl.api.SurrogateSerializer
+import com.ing.serialization.bfl.api.serialize
+import com.ing.serialization.bfl.serde.SerdeError
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+interface Parent
+data class Child(val value: Int) : Parent
+
+object ChildSerializer : KSerializer<Child>
+by (SurrogateSerializer(ChildSurrogate.serializer()) { ChildSurrogate(it.value) })
+
+@Serializable
+@SerialName("CHL")
+data class ChildSurrogate(
+    val value: Int
+) : Surrogate<Child> {
+    override fun toOriginal() = Child(value)
+}
+
+class NoSurrogateSerializerForPolymorphicTest {
+    private val parentSerializers = SerializersModule {
+        polymorphic(Parent::class) {
+            subclass(Child::class, ChildSerializer)
+        }
+    }
+
+    @Serializable
+    data class Data(val myValue: Parent)
+
+    @Test
+    fun `serializer of polymorphic type not inheriting from SurrogateSerializer should throw an error`() {
+        val data = Data(Child(0))
+
+        assertThrows<SerdeError.NoSurrogateSerializerForPolymorphic> {
+            serialize(data, serializersModule = parentSerializers)
+        }
+    }
+}

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/exceptions/NoSurrogateSerializerTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/exceptions/NoSurrogateSerializerTest.kt
@@ -26,7 +26,7 @@ data class ChildSurrogate(
     override fun toOriginal() = Child(value)
 }
 
-class NoSurrogateSerializerForPolymorphicTest {
+class NoSurrogateSerializerTest {
     private val parentSerializers = SerializersModule {
         polymorphic(Parent::class) {
             subclass(Child::class, ChildSerializer)
@@ -40,7 +40,7 @@ class NoSurrogateSerializerForPolymorphicTest {
     fun `serializer of polymorphic type not inheriting from SurrogateSerializer should throw an error`() {
         val data = Data(Child(0))
 
-        assertThrows<SerdeError.NoSurrogateSerializerForPolymorphic> {
+        assertThrows<SerdeError.NoSurrogateSerializer> {
             serialize(data, serializersModule = parentSerializers)
         }
     }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/builtin/ImplementationTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/builtin/ImplementationTest.kt
@@ -8,7 +8,6 @@ import com.ing.serialization.bfl.api.reified.serialize
 import com.ing.serialization.bfl.serde.SerdeError
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
@@ -42,12 +41,9 @@ data class CustomDataSurrogate(
     override fun toOriginal(): CustomData = CustomData(value)
 }
 
-object CustomDataSerializer : KSerializer<CustomData>
-by (
-    SurrogateSerializer(CustomDataSurrogate.serializer()) {
-        CustomDataSurrogate(it.value)
-    }
-    )
+object CustomDataSerializer : SurrogateSerializer<CustomData, CustomDataSurrogate>(
+    CustomDataSurrogate.serializer(), { CustomDataSurrogate(it.value) }
+)
 
 val customDataSerializationModule = SerializersModule {
     contextual(CustomDataSerializer)

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/NullableContextualTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/NullableContextualTest.kt
@@ -1,26 +1,37 @@
 package com.ing.serialization.bfl.serde.serializers.custom
 
 import com.ing.serialization.bfl.annotations.FixedLength
+import com.ing.serialization.bfl.api.Surrogate
+import com.ing.serialization.bfl.api.SurrogateSerializer
 import com.ing.serialization.bfl.api.debugSerialize
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 import org.junit.jupiter.api.Test
 
 class NullableContextualTest {
     @Serializable
     data class Data(val value: @Contextual Wrapper? = Wrapper())
 
+    @Suppress("ArrayInDataClass")
+    data class Wrapper(val bytes: ByteArray = byteArrayOf(1, 2, 3, 4, 5))
+
     @Serializable
     @Suppress("ArrayInDataClass")
-    data class Wrapper(
+    data class WrapperSurrogate(
         @FixedLength([10])
-        val bytes: ByteArray = byteArrayOf(1, 2, 3, 4, 5),
-    )
+        val bytes: ByteArray
+    ) : Surrogate<Wrapper> {
+        override fun toOriginal(): Wrapper = Wrapper(bytes)
+    }
+
+    object WrapperSerializer :
+        SurrogateSerializer<Wrapper, WrapperSurrogate>(WrapperSurrogate.serializer(), { WrapperSurrogate(it.bytes) })
 
     val serializersModule = SerializersModule {
-        contextual(Wrapper::class, Wrapper.serializer())
+        contextual(WrapperSerializer)
     }
 
     @Test

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/ClassPolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/ClassPolymorphicTest.kt
@@ -8,7 +8,6 @@ import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.modules.polymorphic
 import org.junit.jupiter.api.Test
 import java.security.PublicKey
 
@@ -20,8 +19,8 @@ class ClassPolymorphicTest {
     @Test
     fun `Polymorphic type within structure should be serialized successfully`() {
         val mask = listOf(
-            Pair("pk.serialName", PublicKeyBaseSurrogate.SERIAL_NAME_LENGTH),
-            Pair("pk.value", 4 + PublicKeyBaseSurrogate.ENCODED_SIZE)
+            Pair("pk.serialName", RSASurrogate.SERIAL_NAME_LENGTH),
+            Pair("pk.value", 4 + RSASurrogate.ENCODED_SIZE)
         )
 
         val data = Data(generateRSAPubKey())

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/DeepPolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/DeepPolymorphicTest.kt
@@ -3,133 +3,208 @@ package com.ing.serialization.bfl.serde.serializers.custom.polymorphic
 import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.api.Surrogate
 import com.ing.serialization.bfl.api.SurrogateSerializer
-import com.ing.serialization.bfl.api.reified.debugSerialize
-import com.ing.serialization.bfl.api.reified.serialize
-import com.ing.serialization.bfl.serde.SerdeError
-import com.ing.serialization.bfl.serde.roundTrip
-import com.ing.serialization.bfl.serde.sameSize
-import kotlinx.serialization.Contextual
+import com.ing.serialization.bfl.api.serialize
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
 import kotlinx.serialization.modules.polymorphic
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import java.lang.IllegalStateException
+
+// =========================================== Polymorphic GrandParent =========================================== //
+
+interface PolyGrandParent
+data class VariantGrandParentA(val myChild: PolyParent) : PolyGrandParent
+data class VariantGrandParentB(val myChild: PolyParent) : PolyGrandParent
+
+object VariantGrandParentASerializer : KSerializer<VariantGrandParentA>
+by (SurrogateSerializer(VariantGrandParentASurrogate.serializer()) { VariantGrandParentASurrogate(it.myChild) })
+
+@Serializable
+data class VariantGrandParentASurrogate(
+    @SerialName("myChild")
+    val value: PolyParent
+) : Surrogate<VariantGrandParentA> {
+    override fun toOriginal() = VariantGrandParentA(value)
+}
+
+object VariantGrandParentBSerializer : KSerializer<VariantGrandParentB>
+by (SurrogateSerializer(VariantGrandParentBSurrogate.serializer()) { VariantGrandParentBSurrogate(it.myChild) })
+
+@Serializable
+data class VariantGrandParentBSurrogate(
+    @SerialName("myChild")
+    val value: PolyParent
+) : Surrogate<VariantGrandParentB> {
+    override fun toOriginal() = VariantGrandParentB(value)
+}
+
+// =========================================== Polymorphic Parent =========================================== //
+
+interface PolyParent
+data class VariantParentA(val myChild: PolyChild) : PolyParent
+data class VariantParentB(val myChild: PolyChild) : PolyParent
+
+object VariantParentASerializer : KSerializer<VariantParentA>
+by (SurrogateSerializer(VariantParentASurrogate.serializer()) { VariantParentASurrogate(it.myChild) })
+
+@Serializable
+data class VariantParentASurrogate(
+    @SerialName("myChild")
+    val value: PolyChild
+) : Surrogate<VariantParentA> {
+    override fun toOriginal() = VariantParentA(value)
+}
+
+object VariantParentBSerializer : KSerializer<VariantParentB>
+by (SurrogateSerializer(VariantParentBSurrogate.serializer()) { VariantParentBSurrogate(it.myChild) })
+
+@Serializable
+data class VariantParentBSurrogate(
+    @SerialName("myChild")
+    val value: PolyChild
+) : Surrogate<VariantParentB> {
+    override fun toOriginal() = VariantParentB(value)
+}
+
+// =========================================== Polymorphic Child =========================================== //
+
+interface PolyChild
+data class VariantChildA(val myInt: Int) : PolyChild
+data class VariantChildB(val myLong: Long) : PolyChild
+
+object VariantChildASerializer : KSerializer<VariantChildA>
+by (SurrogateSerializer(VariantChildASurrogate.serializer()) { VariantChildASurrogate(it.myInt) })
+
+@Serializable
+data class VariantChildASurrogate(
+    @SerialName("myInt")
+    val value: Int
+) : Surrogate<VariantChildA> {
+    override fun toOriginal() = VariantChildA(value)
+}
+
+object VariantChildBSerializer : KSerializer<VariantChildB>
+by (SurrogateSerializer(VariantChildBSurrogate.serializer()) { VariantChildBSurrogate(it.myLong) })
+
+@Serializable
+data class VariantChildBSurrogate(
+    @SerialName("myLong")
+    val value: Long
+) : Surrogate<VariantChildB> {
+    override fun toOriginal() = VariantChildB(value)
+}
 
 class DeepPolymorphicTest {
     @Serializable
-    data class Data(@FixedLength([2]) val myList: List<Poly>)
+    data class Data(@FixedLength([2]) val myList: List<PolyParent>)
 
     @Serializable
-    data class DataA(@FixedLength([2]) val myList: List<@Contextual VariantA>)
+    data class GrandParentData(@FixedLength([2]) val myList: List<PolyGrandParent>)
 
-    private val failSerializers = SerializersModule {
-        polymorphic(Poly::class) {
-            subclass(VariantA::class, VariantAFailingSerializer)
-            subclass(VariantB::class, VariantBFailingSerializer)
-        }
-    }
+    @Serializable
+    data class ManyData(@FixedLength([2, 2]) val myList1: List<PolyParent>, val myList2: List<PolyParent>)
 
-    private val successSerializers = SerializersModule {
-        polymorphic(Poly::class) {
-            subclass(VariantA::class, VariantASucceedingSerializer)
-            subclass(VariantB::class, VariantBSucceedingSerializer)
+    @Serializable
+    data class NestedData(val myData: Data)
+
+    @Serializable
+    data class NestedListData(@FixedLength([2]) val myDataList: List<Data>)
+
+    private val nestedPolySerializers = SerializersModule {
+        polymorphic(PolyGrandParent::class) {
+            subclass(VariantGrandParentA::class, VariantGrandParentASerializer)
+            subclass(VariantGrandParentB::class, VariantGrandParentBSerializer)
         }
-        contextual(VariantASucceedingSerializer)
-        contextual(VariantBSucceedingSerializer)
+        contextual(VariantGrandParentASerializer)
+        contextual(VariantGrandParentBSerializer)
+
+        polymorphic(PolyParent::class) {
+            subclass(VariantParentA::class, VariantParentASerializer)
+            subclass(VariantParentB::class, VariantParentBSerializer)
+        }
+        contextual(VariantParentASerializer)
+        contextual(VariantParentBSerializer)
+
+        polymorphic(PolyChild::class) {
+            subclass(VariantChildA::class, VariantChildASerializer)
+            subclass(VariantChildB::class, VariantChildBSerializer)
+        }
+        contextual(VariantChildASerializer)
+        contextual(VariantChildBSerializer)
     }
 
     @Test
-    fun `serialization of polymorphic types using different surrogates must fail`() {
-        val data = Data(listOf(VariantA(1), VariantB(2)))
+    fun `different variants of a first-level nested polymorphic type should not coexist in a collection`() {
+        val data1 = VariantParentA(VariantChildA(1))
+        val data2 = VariantParentA(VariantChildA(2))
+        val data3 = VariantParentB(VariantChildA(1))
 
-        println(
-            assertThrows<SerdeError.UnexpectedPrimitive> {
-                serialize(data, serializersModule = failSerializers)
+        listOf(
+            Data(listOf(data1, data2)),
+            ManyData(listOf(data1, data2), listOf(data3)),
+            NestedData(Data(listOf(data1, data2))),
+            NestedListData(listOf(Data(listOf(data1, data2)), Data(listOf(data1)))),
+            GrandParentData(listOf(VariantGrandParentA(data1), VariantGrandParentA(data2))),
+        ).forEach {
+            assertDoesNotThrow {
+                serialize(it, serializersModule = nestedPolySerializers)
             }
-        )
+        }
+
+        listOf(
+            Data(listOf(data1, data3)),
+            ManyData(listOf(data1), listOf(data2, data3)),
+            NestedData(Data(listOf(data2, data3))),
+            NestedListData(listOf(Data(listOf(data1, data2)), Data(listOf(data3)))),
+            GrandParentData(listOf(VariantGrandParentA(data1), VariantGrandParentB(data1))),
+        ).forEach {
+            assertThrows<IllegalStateException> {
+                serialize(it, serializersModule = nestedPolySerializers)
+            }.also { exception ->
+                exception.message shouldBe "Different implementations of the same base type are not allowed"
+            }
+        }
     }
 
     @Test
-    fun `serialization of polymorphic types using same surrogates must not fail`() {
-        val data1 = Data(listOf(VariantA(1), VariantB(2)))
-        val data2 = Data(listOf(VariantB(2)))
+    fun `different variants of a second-level nested polymorphic type should not coexist in a collection`() {
+        val data1 = VariantParentA(VariantChildA(1))
+        val data2 = VariantParentA(VariantChildB(1L))
+        val data3 = VariantParentB(VariantChildA(1))
 
-        println(debugSerialize(data1, serializersModule = successSerializers).second)
-        roundTrip(data1, successSerializers)
-        sameSize(data1, data2, successSerializers)
+        listOf(
+            Data(listOf(data1, data2)),
+            ManyData(listOf(data1), listOf(data1, data2)),
+            NestedData(Data(listOf(data1, data2))),
+            NestedListData(listOf(Data(listOf(data1)), Data(listOf(data2)))),
+            GrandParentData(listOf(VariantGrandParentA(data1), VariantGrandParentA(data3))),
+        ).forEach {
+            assertThrows<IllegalStateException> {
+                serialize(it, serializersModule = nestedPolySerializers)
+            }.also { exception ->
+                exception.message shouldBe "Different implementations of the same base type are not allowed"
+            }
+        }
     }
 
     @Test
-    fun `serialization of exact poly types using same surrogates`() {
-        val data1 = DataA(listOf(VariantA(1), VariantA(2)))
-        val data2 = DataA(listOf(VariantA(2)))
+    fun `different variants of a third-level nested polymorphic type should not coexist in a collection`() {
+        val data1 = VariantParentA(VariantChildA(1))
+        val data2 = VariantParentA(VariantChildB(1L))
 
-        println(debugSerialize(data1, serializersModule = successSerializers).second)
-        roundTrip(data1, successSerializers)
-        sameSize(data1, data2, successSerializers)
+        assertThrows<IllegalStateException> {
+            serialize(
+                GrandParentData(listOf(VariantGrandParentA(data1), VariantGrandParentA(data2))),
+                serializersModule = nestedPolySerializers
+            )
+        }.also { exception ->
+            exception.message shouldBe "Different implementations of the same base type are not allowed"
+        }
     }
-}
-
-// These types are considered to be 3rd party types. -->
-interface Poly
-data class VariantA(val myInt: Int) : Poly
-data class VariantB(val myLong: Long) : Poly
-// <--
-
-// This is a failing serializing strategy, because variant serializers use surrogates resulting in different lengths -->
-object VariantAFailingSerializer : KSerializer<VariantA>
-by (SurrogateSerializer(VariantAFailingSurrogate.serializer()) { VariantAFailingSurrogate(it.myInt) })
-
-object VariantBFailingSerializer : KSerializer<VariantB>
-by (SurrogateSerializer(VariantBFailingSurrogate.serializer()) { VariantBFailingSurrogate(it.myLong) })
-
-@Suppress("ArrayInDataClass")
-@Serializable
-data class VariantAFailingSurrogate(val value: Int) : Surrogate<VariantA> {
-    override fun toOriginal() = VariantA(value)
-}
-
-@Suppress("ArrayInDataClass")
-@Serializable
-data class VariantBFailingSurrogate(val value: Long) : Surrogate<VariantB> {
-    override fun toOriginal() = VariantB(value)
-}
-// <-- Failing strategy end.
-
-object VariantASucceedingSerializer : KSerializer<VariantA>
-by (
-    SurrogateSerializer(VariantASucceedingSurrogate.serializer()) {
-        VariantASucceedingSurrogate(myInt = it.myInt)
-    }
-    )
-
-object VariantBSucceedingSerializer : KSerializer<VariantB>
-by (
-    SurrogateSerializer(VariantBSucceedingSurrogate.serializer()) {
-        VariantBSucceedingSurrogate(myLong = it.myLong)
-    }
-    )
-
-@Serializable
-abstract class PolyBaseSurrogate {
-    abstract val myLong: Long?
-    abstract val myInt: Int?
-}
-
-@Serializable
-class VariantASucceedingSurrogate(
-    override val myLong: Long? = null,
-    override val myInt: Int?
-) : PolyBaseSurrogate(), Surrogate<VariantA> {
-    override fun toOriginal() = VariantA(myInt!!)
-}
-
-@Serializable
-class VariantBSucceedingSurrogate(
-    override val myLong: Long?,
-    override val myInt: Int? = null
-) : PolyBaseSurrogate(), Surrogate<VariantB> {
-    override fun toOriginal() = VariantB(myLong!!)
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/DeepPolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/DeepPolymorphicTest.kt
@@ -4,17 +4,21 @@ import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.api.Surrogate
 import com.ing.serialization.bfl.api.SurrogateSerializer
 import com.ing.serialization.bfl.api.serialize
-import io.kotest.matchers.shouldBe
+import com.ing.serialization.bfl.serde.SerdeError
+import com.ing.serialization.bfl.serde.checkedSerialize
+import com.ing.serialization.bfl.serde.checkedSerializeInlined
+import com.ing.serialization.bfl.serde.element.ElementFactory
+import com.ing.serialization.bfl.serde.roundTrip
+import com.ing.serialization.bfl.serde.roundTripInlined
+import com.ing.serialization.bfl.serde.sameSize
+import com.ing.serialization.bfl.serde.sameSizeInlined
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
 import kotlinx.serialization.modules.polymorphic
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import java.lang.IllegalStateException
 
 // =========================================== Polymorphic GrandParent =========================================== //
 
@@ -23,25 +27,31 @@ data class VariantGrandParentA(val myChild: PolyParent) : PolyGrandParent
 data class VariantGrandParentB(val myChild: PolyParent) : PolyGrandParent
 
 object VariantGrandParentASerializer : KSerializer<VariantGrandParentA>
-by (SurrogateSerializer(VariantGrandParentASurrogate.serializer()) { VariantGrandParentASurrogate(it.myChild) })
+by (SurrogateSerializer(VariantGrandParentASurrogate.serializer()) { VariantGrandParentASurrogate.from(it) })
 
 @Serializable
 data class VariantGrandParentASurrogate(
-    @SerialName("myChild")
     val value: PolyParent
 ) : Surrogate<VariantGrandParentA> {
     override fun toOriginal() = VariantGrandParentA(value)
+    companion object {
+        fun from(variantGrandParentA: VariantGrandParentA): VariantGrandParentASurrogate =
+            VariantGrandParentASurrogate(variantGrandParentA.myChild)
+    }
 }
 
 object VariantGrandParentBSerializer : KSerializer<VariantGrandParentB>
-by (SurrogateSerializer(VariantGrandParentBSurrogate.serializer()) { VariantGrandParentBSurrogate(it.myChild) })
+by (SurrogateSerializer(VariantGrandParentBSurrogate.serializer()) { VariantGrandParentBSurrogate.from(it) })
 
 @Serializable
 data class VariantGrandParentBSurrogate(
-    @SerialName("myChild")
     val value: PolyParent
 ) : Surrogate<VariantGrandParentB> {
     override fun toOriginal() = VariantGrandParentB(value)
+    companion object {
+        fun from(variantGrandParentB: VariantGrandParentB): VariantGrandParentBSurrogate =
+            VariantGrandParentBSurrogate(variantGrandParentB.myChild)
+    }
 }
 
 // =========================================== Polymorphic Parent =========================================== //
@@ -51,25 +61,29 @@ data class VariantParentA(val myChild: PolyChild) : PolyParent
 data class VariantParentB(val myChild: PolyChild) : PolyParent
 
 object VariantParentASerializer : KSerializer<VariantParentA>
-by (SurrogateSerializer(VariantParentASurrogate.serializer()) { VariantParentASurrogate(it.myChild) })
+by (SurrogateSerializer(VariantParentASurrogate.serializer()) { VariantParentASurrogate.from(it) })
 
 @Serializable
 data class VariantParentASurrogate(
-    @SerialName("myChild")
     val value: PolyChild
 ) : Surrogate<VariantParentA> {
     override fun toOriginal() = VariantParentA(value)
+    companion object {
+        fun from(variantParentA: VariantParentA): VariantParentASurrogate = VariantParentASurrogate(variantParentA.myChild)
+    }
 }
 
 object VariantParentBSerializer : KSerializer<VariantParentB>
-by (SurrogateSerializer(VariantParentBSurrogate.serializer()) { VariantParentBSurrogate(it.myChild) })
+by (SurrogateSerializer(VariantParentBSurrogate.serializer()) { VariantParentBSurrogate.from(it) })
 
 @Serializable
 data class VariantParentBSurrogate(
-    @SerialName("myChild")
     val value: PolyChild
 ) : Surrogate<VariantParentB> {
     override fun toOriginal() = VariantParentB(value)
+    companion object {
+        fun from(variantParentB: VariantParentB): VariantParentBSurrogate = VariantParentBSurrogate(variantParentB.myChild)
+    }
 }
 
 // =========================================== Polymorphic Child =========================================== //
@@ -79,43 +93,32 @@ data class VariantChildA(val myInt: Int) : PolyChild
 data class VariantChildB(val myLong: Long) : PolyChild
 
 object VariantChildASerializer : KSerializer<VariantChildA>
-by (SurrogateSerializer(VariantChildASurrogate.serializer()) { VariantChildASurrogate(it.myInt) })
+by (SurrogateSerializer(VariantChildASurrogate.serializer()) { VariantChildASurrogate.from(it) })
 
 @Serializable
 data class VariantChildASurrogate(
-    @SerialName("myInt")
     val value: Int
 ) : Surrogate<VariantChildA> {
     override fun toOriginal() = VariantChildA(value)
+    companion object {
+        fun from(variantChildA: VariantChildA): VariantChildASurrogate = VariantChildASurrogate(variantChildA.myInt)
+    }
 }
 
 object VariantChildBSerializer : KSerializer<VariantChildB>
-by (SurrogateSerializer(VariantChildBSurrogate.serializer()) { VariantChildBSurrogate(it.myLong) })
+by (SurrogateSerializer(VariantChildBSurrogate.serializer()) { VariantChildBSurrogate.from(it) })
 
 @Serializable
 data class VariantChildBSurrogate(
-    @SerialName("myLong")
     val value: Long
 ) : Surrogate<VariantChildB> {
     override fun toOriginal() = VariantChildB(value)
+    companion object {
+        fun from(variantChildB: VariantChildB): VariantChildBSurrogate = VariantChildBSurrogate(variantChildB.myLong)
+    }
 }
 
 class DeepPolymorphicTest {
-    @Serializable
-    data class Data(@FixedLength([2]) val myList: List<PolyParent>)
-
-    @Serializable
-    data class GrandParentData(@FixedLength([2]) val myList: List<PolyGrandParent>)
-
-    @Serializable
-    data class ManyData(@FixedLength([2, 2]) val myList1: List<PolyParent>, val myList2: List<PolyParent>)
-
-    @Serializable
-    data class NestedData(val myData: Data)
-
-    @Serializable
-    data class NestedListData(@FixedLength([2]) val myDataList: List<Data>)
-
     private val nestedPolySerializers = SerializersModule {
         polymorphic(PolyGrandParent::class) {
             subclass(VariantGrandParentA::class, VariantGrandParentASerializer)
@@ -139,23 +142,249 @@ class DeepPolymorphicTest {
         contextual(VariantChildBSerializer)
     }
 
+    @Serializable
+    data class Data(@FixedLength([2]) val myList: List<PolyParent>)
+
+    @Test
+    fun `polymorphic nested in list should be serialized successfully`() {
+        val mask = listOf(
+            Pair("myList.length", 4),
+            Pair("myList[0].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[0].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[0].polyParent.polyChild.value", 4),
+            Pair("myList[1].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[1].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[1].polyParent.polyChild.value", 4),
+        )
+        val data = Data(listOf(VariantParentA(VariantChildA(1)), VariantParentA(VariantChildA(2))))
+
+        checkedSerializeInlined(data, mask, nestedPolySerializers)
+        checkedSerialize(data, mask, nestedPolySerializers)
+    }
+
+    @Test
+    fun `polymorphic nested in list should be the same after serialization and deserialization`() {
+        val data = Data(listOf(VariantParentA(VariantChildA(1)), VariantParentA(VariantChildA(2))))
+
+        roundTripInlined(data, nestedPolySerializers)
+        roundTrip(data, nestedPolySerializers)
+    }
+
+    @Test
+    fun `different polymorphic nested in list should have same size after serialization`() {
+        val data1 = Data(listOf(VariantParentA(VariantChildA(1)), VariantParentA(VariantChildA(2))))
+        val data2 = Data(listOf(VariantParentA(VariantChildA(1))))
+
+        sameSizeInlined(data1, data2, nestedPolySerializers)
+        sameSize(data1, data2, nestedPolySerializers)
+    }
+
+    @Serializable
+    data class ManyData(@FixedLength([2, 2]) val myList1: List<PolyParent>, val myList2: List<PolyParent>)
+
+    @Test
+    fun `polymorphic nested in different lists should be serialized successfully`() {
+        val mask = listOf(
+            Pair("myList1.length", 4),
+            Pair("myList1[0].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList1[0].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList1[0].polyParent.polyChild.value", 4),
+            Pair("myList1[1].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList1[1].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList1[1].polyParent.polyChild.value", 4),
+            Pair("myList2.length", 4),
+            Pair("myList2[0].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList2[0].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList2[0].polyParent.polyChild.value", 4),
+            Pair("myList2[1].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList2[1].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList2[1].polyParent.polyChild.value", 4),
+        )
+        val data = ManyData(
+            listOf(VariantParentA(VariantChildA(1)), VariantParentA(VariantChildA(2))),
+            listOf(VariantParentA(VariantChildA(2)))
+        )
+
+        checkedSerialize(data, mask, nestedPolySerializers)
+        checkedSerializeInlined(data, mask, nestedPolySerializers)
+    }
+
+    @Test
+    fun `polymorphic nested in different lists should be the same after serialization and deserialization`() {
+        val data = ManyData(
+            listOf(VariantParentA(VariantChildA(1)), VariantParentA(VariantChildA(2))),
+            listOf(VariantParentA(VariantChildA(2)))
+        )
+
+        roundTripInlined(data, nestedPolySerializers)
+        roundTrip(data, nestedPolySerializers)
+    }
+
+    @Test
+    fun `different polymorphic nested in different lists should have same size after serialization`() {
+        val data1 = ManyData(
+            listOf(VariantParentA(VariantChildA(1)), VariantParentA(VariantChildA(2))),
+            listOf(VariantParentA(VariantChildA(2)))
+        )
+        val data2 = ManyData(
+            listOf(VariantParentA(VariantChildA(1))),
+            listOf(VariantParentA(VariantChildA(2)))
+        )
+
+        sameSizeInlined(data1, data2, nestedPolySerializers)
+        sameSize(data1, data2, nestedPolySerializers)
+    }
+
+    @Serializable
+    data class NestedData(val myData: Data)
+
+    @Test
+    fun `polymorphic nested within structure should be serialized successfully`() {
+        val mask = listOf(
+            Pair("myData.myList.length", 4),
+            Pair("myData.myList[0].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myData.myList[0].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myData.myList[0].polyParent.polyChild.value", 4),
+            Pair("myData.myList[1].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myData.myList[1].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myData.myList[1].polyParent.polyChild.value", 4),
+        )
+        val data = NestedData(Data(listOf(VariantParentA(VariantChildA(1)), VariantParentA(VariantChildA(2)))))
+
+        checkedSerializeInlined(data, mask, nestedPolySerializers)
+        checkedSerialize(data, mask, nestedPolySerializers)
+    }
+
+    @Test
+    fun `polymorphic nested within structure should be the same after serialization and deserialization`() {
+        val data = NestedData(Data(listOf(VariantParentA(VariantChildA(1)), VariantParentA(VariantChildA(2)))))
+
+        roundTripInlined(data, nestedPolySerializers)
+        roundTrip(data, nestedPolySerializers)
+    }
+
+    @Test
+    fun `different polymorphic nested within structure should have same size after serialization`() {
+        val data1 = NestedData(Data(listOf(VariantParentA(VariantChildA(1)), VariantParentA(VariantChildA(2)))))
+        val data2 = NestedData(Data(listOf(VariantParentA(VariantChildA(1)))))
+
+        sameSizeInlined(data1, data2, nestedPolySerializers)
+        sameSize(data1, data2, nestedPolySerializers)
+    }
+
+    @Serializable
+    data class NestedListData(@FixedLength([2]) val myDataList: List<Data>)
+
+    @Test
+    fun `polymorphic nested in list of structure should be serialized successfully`() {
+        val mask = listOf(
+            Pair("myDataList.length", 4),
+            Pair("myDataList[0].myList.length", 4),
+            Pair("myDataList[0].myList[0].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myDataList[0].myList[0].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myDataList[0].myList[0].polyParent.polyChild.value", 4),
+            Pair("myDataList[0].myList[1].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myDataList[0].myList[1].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myDataList[0].myList[1].polyParent.polyChild.value", 4),
+            Pair("myDataList[1].myList.length", 4),
+            Pair("myDataList[1].myList[0].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myDataList[1].myList[0].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myDataList[1].myList[0].polyParent.polyChild.value", 4),
+            Pair("myDataList[1].myList[1].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myDataList[1].myList[1].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myDataList[1].myList[1].polyParent.polyChild.value", 4),
+        )
+        val data = NestedListData(listOf(Data(listOf(VariantParentA(VariantChildA(1))))))
+
+        checkedSerialize(data, mask, nestedPolySerializers)
+        checkedSerializeInlined(data, mask, nestedPolySerializers)
+    }
+
+    @Test
+    fun `polymorphic nested in list of structure should be the same after serialization and deserialization`() {
+        val data = NestedListData(listOf(Data(listOf(VariantParentA(VariantChildA(1))))))
+
+        roundTripInlined(data, nestedPolySerializers)
+        roundTrip(data, nestedPolySerializers)
+    }
+
+    @Test
+    fun `different polymorphic nested in list of structure should have same size after serialization`() {
+        val data1 = NestedListData(listOf(Data(listOf(VariantParentA(VariantChildA(1))))))
+        val data2 = NestedListData(
+            listOf(
+                Data(listOf(VariantParentA(VariantChildA(1)))),
+                Data(listOf(VariantParentA(VariantChildA(2)))),
+            )
+        )
+
+        sameSizeInlined(data1, data2, nestedPolySerializers)
+        sameSize(data1, data2, nestedPolySerializers)
+    }
+
+    @Serializable
+    data class GrandParentData(@FixedLength([2]) val myList: List<PolyGrandParent>)
+
+    @Test
+    fun `third-level nested polymorphic should be serialized successfully`() {
+        val mask = listOf(
+            Pair("myList.length", 4),
+            Pair("myList[0].PolyGrandParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[0].PolyGrandParent.polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[0].PolyGrandParent.polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[0].PolyGrandParent.polyParent.polyChild.value", 4),
+            Pair("myList[1].PolyGrandParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[1].PolyGrandParent.polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[1].PolyGrandParent.polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[1].PolyGrandParent.polyParent.polyChild.value", 4),
+        )
+        val data = GrandParentData(
+            listOf(
+                VariantGrandParentA(VariantParentA(VariantChildA(1))),
+                VariantGrandParentA(VariantParentA(VariantChildA(2)))
+            )
+        )
+
+        checkedSerializeInlined(data, mask, nestedPolySerializers)
+        checkedSerialize(data, mask, nestedPolySerializers)
+    }
+
+    @Test
+    fun `third-level nested polymorphic  should be the same after serialization and deserialization`() {
+        val data = GrandParentData(
+            listOf(
+                VariantGrandParentA(VariantParentA(VariantChildA(1))),
+                VariantGrandParentA(VariantParentA(VariantChildA(2)))
+            )
+        )
+
+        roundTripInlined(data, nestedPolySerializers)
+        roundTrip(data, nestedPolySerializers)
+    }
+
+    @Test
+    fun `third-level nested polymorphic  in list should have same size after serialization`() {
+        val data1 = GrandParentData(
+            listOf(
+                VariantGrandParentA(VariantParentA(VariantChildA(1))),
+                VariantGrandParentA(VariantParentA(VariantChildA(2)))
+            )
+        )
+        val data2 = GrandParentData(
+            listOf(
+                VariantGrandParentA(VariantParentA(VariantChildA(1))),
+            )
+        )
+
+        sameSizeInlined(data1, data2, nestedPolySerializers)
+        sameSize(data1, data2, nestedPolySerializers)
+    }
+
     @Test
     fun `different variants of a first-level nested polymorphic type should not coexist in a collection`() {
         val data1 = VariantParentA(VariantChildA(1))
         val data2 = VariantParentA(VariantChildA(2))
         val data3 = VariantParentB(VariantChildA(1))
-
-        listOf(
-            Data(listOf(data1, data2)),
-            ManyData(listOf(data1, data2), listOf(data3)),
-            NestedData(Data(listOf(data1, data2))),
-            NestedListData(listOf(Data(listOf(data1, data2)), Data(listOf(data1)))),
-            GrandParentData(listOf(VariantGrandParentA(data1), VariantGrandParentA(data2))),
-        ).forEach {
-            assertDoesNotThrow {
-                serialize(it, serializersModule = nestedPolySerializers)
-            }
-        }
 
         listOf(
             Data(listOf(data1, data3)),
@@ -164,10 +393,8 @@ class DeepPolymorphicTest {
             NestedListData(listOf(Data(listOf(data1, data2)), Data(listOf(data3)))),
             GrandParentData(listOf(VariantGrandParentA(data1), VariantGrandParentB(data1))),
         ).forEach {
-            assertThrows<IllegalStateException> {
+            assertThrows<SerdeError.DifferentPolymorphicImplementations> {
                 serialize(it, serializersModule = nestedPolySerializers)
-            }.also { exception ->
-                exception.message shouldBe "Different implementations of the same base type are not allowed"
             }
         }
     }
@@ -185,10 +412,8 @@ class DeepPolymorphicTest {
             NestedListData(listOf(Data(listOf(data1)), Data(listOf(data2)))),
             GrandParentData(listOf(VariantGrandParentA(data1), VariantGrandParentA(data3))),
         ).forEach {
-            assertThrows<IllegalStateException> {
+            assertThrows<SerdeError.DifferentPolymorphicImplementations> {
                 serialize(it, serializersModule = nestedPolySerializers)
-            }.also { exception ->
-                exception.message shouldBe "Different implementations of the same base type are not allowed"
             }
         }
     }
@@ -198,13 +423,11 @@ class DeepPolymorphicTest {
         val data1 = VariantParentA(VariantChildA(1))
         val data2 = VariantParentA(VariantChildB(1L))
 
-        assertThrows<IllegalStateException> {
+        assertThrows<SerdeError.DifferentPolymorphicImplementations> {
             serialize(
                 GrandParentData(listOf(VariantGrandParentA(data1), VariantGrandParentA(data2))),
                 serializersModule = nestedPolySerializers
             )
-        }.also { exception ->
-            exception.message shouldBe "Different implementations of the same base type are not allowed"
         }
     }
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/DeepPolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/DeepPolymorphicTest.kt
@@ -7,50 +7,54 @@ import com.ing.serialization.bfl.api.serialize
 import com.ing.serialization.bfl.serde.SerdeError
 import com.ing.serialization.bfl.serde.checkedSerialize
 import com.ing.serialization.bfl.serde.checkedSerializeInlined
-import com.ing.serialization.bfl.serde.element.ElementFactory
 import com.ing.serialization.bfl.serde.roundTrip
 import com.ing.serialization.bfl.serde.roundTripInlined
 import com.ing.serialization.bfl.serde.sameSize
 import com.ing.serialization.bfl.serde.sameSizeInlined
-import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.contextual
 import kotlinx.serialization.modules.polymorphic
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
-// =========================================== Polymorphic GrandParent =========================================== //
+// =========================================== Polymorphic Child =========================================== //
 
-interface PolyGrandParent
-data class VariantGrandParentA(val myChild: PolyParent) : PolyGrandParent
-data class VariantGrandParentB(val myChild: PolyParent) : PolyGrandParent
+interface PolyChild
+data class VariantChildA(val myInt: Int) : PolyChild
+data class VariantChildB(val myLong: Long) : PolyChild
 
-object VariantGrandParentASerializer : KSerializer<VariantGrandParentA>
-by (SurrogateSerializer(VariantGrandParentASurrogate.serializer()) { VariantGrandParentASurrogate.from(it) })
+object VariantChildASerializer :
+    SurrogateSerializer<VariantChildA, VariantChildASurrogate>(
+        VariantChildASurrogate.serializer(),
+        { VariantChildASurrogate(it.myInt) }
+    )
 
 @Serializable
-data class VariantGrandParentASurrogate(
-    val value: PolyParent
-) : Surrogate<VariantGrandParentA> {
-    override fun toOriginal() = VariantGrandParentA(value)
+@SerialName("CHA")
+data class VariantChildASurrogate(
+    val value: Int
+) : Surrogate<VariantChildA> {
+    override fun toOriginal() = VariantChildA(value)
     companion object {
-        fun from(variantGrandParentA: VariantGrandParentA): VariantGrandParentASurrogate =
-            VariantGrandParentASurrogate(variantGrandParentA.myChild)
+        const val SERIAL_NAME_LENGTH = 2 + 2 * 3
     }
 }
 
-object VariantGrandParentBSerializer : KSerializer<VariantGrandParentB>
-by (SurrogateSerializer(VariantGrandParentBSurrogate.serializer()) { VariantGrandParentBSurrogate.from(it) })
+object VariantChildBSerializer :
+    SurrogateSerializer<VariantChildB, VariantChildBSurrogate>(
+        VariantChildBSurrogate.serializer(),
+        { VariantChildBSurrogate(it.myLong) }
+    )
 
 @Serializable
-data class VariantGrandParentBSurrogate(
-    val value: PolyParent
-) : Surrogate<VariantGrandParentB> {
-    override fun toOriginal() = VariantGrandParentB(value)
+@SerialName("CHB")
+data class VariantChildBSurrogate(
+    val value: Long
+) : Surrogate<VariantChildB> {
+    override fun toOriginal() = VariantChildB(value)
     companion object {
-        fun from(variantGrandParentB: VariantGrandParentB): VariantGrandParentBSurrogate =
-            VariantGrandParentBSurrogate(variantGrandParentB.myChild)
+        const val SERIAL_NAME_LENGTH = 2 + 2 * 3
     }
 }
 
@@ -60,61 +64,77 @@ interface PolyParent
 data class VariantParentA(val myChild: PolyChild) : PolyParent
 data class VariantParentB(val myChild: PolyChild) : PolyParent
 
-object VariantParentASerializer : KSerializer<VariantParentA>
-by (SurrogateSerializer(VariantParentASurrogate.serializer()) { VariantParentASurrogate.from(it) })
+object VariantParentASerializer :
+    SurrogateSerializer<VariantParentA, VariantParentASurrogate>(
+        VariantParentASurrogate.serializer(),
+        { VariantParentASurrogate(it.myChild) }
+    )
 
 @Serializable
+@SerialName("PA")
 data class VariantParentASurrogate(
     val value: PolyChild
 ) : Surrogate<VariantParentA> {
     override fun toOriginal() = VariantParentA(value)
     companion object {
-        fun from(variantParentA: VariantParentA): VariantParentASurrogate = VariantParentASurrogate(variantParentA.myChild)
+        const val SERIAL_NAME_LENGTH = 2 + 2 * 2
     }
 }
 
-object VariantParentBSerializer : KSerializer<VariantParentB>
-by (SurrogateSerializer(VariantParentBSurrogate.serializer()) { VariantParentBSurrogate.from(it) })
+object VariantParentBSerializer :
+    SurrogateSerializer<VariantParentB, VariantParentBSurrogate>(
+        VariantParentBSurrogate.serializer(),
+        { VariantParentBSurrogate(it.myChild) }
+    )
 
 @Serializable
+@SerialName("PB")
 data class VariantParentBSurrogate(
     val value: PolyChild
 ) : Surrogate<VariantParentB> {
     override fun toOriginal() = VariantParentB(value)
     companion object {
-        fun from(variantParentB: VariantParentB): VariantParentBSurrogate = VariantParentBSurrogate(variantParentB.myChild)
+        const val SERIAL_NAME_LENGTH = 2 + 2 * 2
     }
 }
 
-// =========================================== Polymorphic Child =========================================== //
+// =========================================== Polymorphic GrandParent =========================================== //
 
-interface PolyChild
-data class VariantChildA(val myInt: Int) : PolyChild
-data class VariantChildB(val myLong: Long) : PolyChild
+interface PolyGrandParent
+data class VariantGrandParentA(val myChild: PolyParent) : PolyGrandParent
+data class VariantGrandParentB(val myChild: PolyParent) : PolyGrandParent
 
-object VariantChildASerializer : KSerializer<VariantChildA>
-by (SurrogateSerializer(VariantChildASurrogate.serializer()) { VariantChildASurrogate.from(it) })
+object VariantGrandParentASerializer :
+    SurrogateSerializer<VariantGrandParentA, VariantGrandParentASurrogate>(
+        VariantGrandParentASurrogate.serializer(),
+        { VariantGrandParentASurrogate(it.myChild) }
+    )
 
 @Serializable
-data class VariantChildASurrogate(
-    val value: Int
-) : Surrogate<VariantChildA> {
-    override fun toOriginal() = VariantChildA(value)
+@SerialName("GPA")
+data class VariantGrandParentASurrogate(
+    val value: PolyParent
+) : Surrogate<VariantGrandParentA> {
+    override fun toOriginal() = VariantGrandParentA(value)
     companion object {
-        fun from(variantChildA: VariantChildA): VariantChildASurrogate = VariantChildASurrogate(variantChildA.myInt)
+        const val SERIAL_NAME_LENGTH = 2 + 2 * 3
     }
 }
 
-object VariantChildBSerializer : KSerializer<VariantChildB>
-by (SurrogateSerializer(VariantChildBSurrogate.serializer()) { VariantChildBSurrogate.from(it) })
+object VariantGrandParentBSerializer :
+    SurrogateSerializer<VariantGrandParentB, VariantGrandParentBSurrogate>(
+        VariantGrandParentBSurrogate.serializer(),
+        { VariantGrandParentBSurrogate(it.myChild) }
+    )
 
 @Serializable
-data class VariantChildBSurrogate(
-    val value: Long
-) : Surrogate<VariantChildB> {
-    override fun toOriginal() = VariantChildB(value)
+@SerialName("GPB")
+data class VariantGrandParentBSurrogate(
+    val value: PolyParent
+) : Surrogate<VariantGrandParentB> {
+    override fun toOriginal() = VariantGrandParentB(value)
     companion object {
-        fun from(variantChildB: VariantChildB): VariantChildBSurrogate = VariantChildBSurrogate(variantChildB.myLong)
+        const val SERIAL_NAME_LENGTH = 2 + 2 * 3
     }
 }
 
@@ -124,22 +144,16 @@ class DeepPolymorphicTest {
             subclass(VariantGrandParentA::class, VariantGrandParentASerializer)
             subclass(VariantGrandParentB::class, VariantGrandParentBSerializer)
         }
-        contextual(VariantGrandParentASerializer)
-        contextual(VariantGrandParentBSerializer)
 
         polymorphic(PolyParent::class) {
             subclass(VariantParentA::class, VariantParentASerializer)
             subclass(VariantParentB::class, VariantParentBSerializer)
         }
-        contextual(VariantParentASerializer)
-        contextual(VariantParentBSerializer)
 
         polymorphic(PolyChild::class) {
             subclass(VariantChildA::class, VariantChildASerializer)
             subclass(VariantChildB::class, VariantChildBSerializer)
         }
-        contextual(VariantChildASerializer)
-        contextual(VariantChildBSerializer)
     }
 
     @Serializable
@@ -149,11 +163,11 @@ class DeepPolymorphicTest {
     fun `polymorphic nested in list should be serialized successfully`() {
         val mask = listOf(
             Pair("myList.length", 4),
-            Pair("myList[0].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myList[0].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[0].polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myList[0].polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myList[0].polyParent.polyChild.value", 4),
-            Pair("myList[1].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myList[1].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[1].polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myList[1].polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myList[1].polyParent.polyChild.value", 4),
         )
         val data = Data(listOf(VariantParentA(VariantChildA(1)), VariantParentA(VariantChildA(2))))
@@ -186,18 +200,18 @@ class DeepPolymorphicTest {
     fun `polymorphic nested in different lists should be serialized successfully`() {
         val mask = listOf(
             Pair("myList1.length", 4),
-            Pair("myList1[0].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myList1[0].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList1[0].polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myList1[0].polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myList1[0].polyParent.polyChild.value", 4),
-            Pair("myList1[1].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myList1[1].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList1[1].polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myList1[1].polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myList1[1].polyParent.polyChild.value", 4),
             Pair("myList2.length", 4),
-            Pair("myList2[0].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myList2[0].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList2[0].polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myList2[0].polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myList2[0].polyParent.polyChild.value", 4),
-            Pair("myList2[1].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myList2[1].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList2[1].polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myList2[1].polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myList2[1].polyParent.polyChild.value", 4),
         )
         val data = ManyData(
@@ -242,11 +256,11 @@ class DeepPolymorphicTest {
     fun `polymorphic nested within structure should be serialized successfully`() {
         val mask = listOf(
             Pair("myData.myList.length", 4),
-            Pair("myData.myList[0].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myData.myList[0].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myData.myList[0].polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myData.myList[0].polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myData.myList[0].polyParent.polyChild.value", 4),
-            Pair("myData.myList[1].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myData.myList[1].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myData.myList[1].polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myData.myList[1].polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myData.myList[1].polyParent.polyChild.value", 4),
         )
         val data = NestedData(Data(listOf(VariantParentA(VariantChildA(1)), VariantParentA(VariantChildA(2)))))
@@ -280,18 +294,18 @@ class DeepPolymorphicTest {
         val mask = listOf(
             Pair("myDataList.length", 4),
             Pair("myDataList[0].myList.length", 4),
-            Pair("myDataList[0].myList[0].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myDataList[0].myList[0].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myDataList[0].myList[0].polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myDataList[0].myList[0].polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myDataList[0].myList[0].polyParent.polyChild.value", 4),
-            Pair("myDataList[0].myList[1].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myDataList[0].myList[1].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myDataList[0].myList[1].polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myDataList[0].myList[1].polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myDataList[0].myList[1].polyParent.polyChild.value", 4),
             Pair("myDataList[1].myList.length", 4),
-            Pair("myDataList[1].myList[0].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myDataList[1].myList[0].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myDataList[1].myList[0].polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myDataList[1].myList[0].polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myDataList[1].myList[0].polyParent.polyChild.value", 4),
-            Pair("myDataList[1].myList[1].polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myDataList[1].myList[1].polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myDataList[1].myList[1].polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myDataList[1].myList[1].polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myDataList[1].myList[1].polyParent.polyChild.value", 4),
         )
         val data = NestedListData(listOf(Data(listOf(VariantParentA(VariantChildA(1))))))
@@ -329,13 +343,13 @@ class DeepPolymorphicTest {
     fun `third-level nested polymorphic should be serialized successfully`() {
         val mask = listOf(
             Pair("myList.length", 4),
-            Pair("myList[0].PolyGrandParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myList[0].PolyGrandParent.polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myList[0].PolyGrandParent.polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[0].PolyGrandParent.serialName", VariantGrandParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myList[0].PolyGrandParent.polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myList[0].PolyGrandParent.polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myList[0].PolyGrandParent.polyParent.polyChild.value", 4),
-            Pair("myList[1].PolyGrandParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myList[1].PolyGrandParent.polyParent.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
-            Pair("myList[1].PolyGrandParent.polyParent.polyChild.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("myList[1].PolyGrandParent.serialName", VariantGrandParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myList[1].PolyGrandParent.polyParent.serialName", VariantParentASurrogate.SERIAL_NAME_LENGTH),
+            Pair("myList[1].PolyGrandParent.polyParent.polyChild.serialName", VariantChildASurrogate.SERIAL_NAME_LENGTH),
             Pair("myList[1].PolyGrandParent.polyParent.polyChild.value", 4),
         )
         val data = GrandParentData(

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/ListPolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/ListPolymorphicTest.kt
@@ -25,12 +25,12 @@ class ListPolymorphicTest {
     fun `List of polymorphic type should be serialized successfully`() {
         val mask = listOf(
             Pair("nested.length", 4),
-            Pair("nested[0].serialName", PublicKeyBaseSurrogate.SERIAL_NAME_LENGTH),
+            Pair("nested[0].serialName", RSASurrogate.SERIAL_NAME_LENGTH),
             Pair("nested[0].length", 4),
-            Pair("nested[0].value", PublicKeyBaseSurrogate.ENCODED_SIZE),
-            Pair("nested[1].serialName", PublicKeyBaseSurrogate.SERIAL_NAME_LENGTH),
+            Pair("nested[0].value", RSASurrogate.ENCODED_SIZE),
+            Pair("nested[1].serialName", RSASurrogate.SERIAL_NAME_LENGTH),
             Pair("nested[1].length", 4),
-            Pair("nested[1].value", PublicKeyBaseSurrogate.ENCODED_SIZE)
+            Pair("nested[1].value", RSASurrogate.ENCODED_SIZE)
         )
 
         val data = Data(listOf(generateRSAPubKey()))
@@ -48,12 +48,9 @@ class ListPolymorphicTest {
 
     @Test
     fun `different Lists of polymorphic type should have same size after serialization`() {
-        val empty = Data(listOf())
         val data1 = Data(listOf(generateRSAPubKey()))
         val data2 = Data(listOf(generateRSAPubKey()))
 
-        sameSizeInlined(empty, data1, PolySerializers)
-        sameSize(empty, data1, PolySerializers)
         sameSizeInlined(data2, data1, PolySerializers)
         sameSize(data2, data1, PolySerializers)
     }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/NestedClassesPolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/NestedClassesPolymorphicTest.kt
@@ -2,7 +2,6 @@ package com.ing.serialization.bfl.serde.serializers.custom.polymorphic
 
 import com.ing.serialization.bfl.serde.checkedSerialize
 import com.ing.serialization.bfl.serde.checkedSerializeInlined
-import com.ing.serialization.bfl.serde.generateDSAPubKey
 import com.ing.serialization.bfl.serde.generateRSAPubKey
 import com.ing.serialization.bfl.serde.roundTrip
 import com.ing.serialization.bfl.serde.roundTripInlined
@@ -25,9 +24,9 @@ class NestedClassesPolymorphicTest {
         val data = Data(Some(generateRSAPubKey()))
 
         val mask = listOf(
-            Pair("some.pk.serialName", PublicKeyBaseSurrogate.SERIAL_NAME_LENGTH),
+            Pair("some.pk.serialName", RSASurrogate.SERIAL_NAME_LENGTH),
             Pair("some.pk.length", 4),
-            Pair("some.nested.value", PublicKeyBaseSurrogate.ENCODED_SIZE)
+            Pair("some.nested.value", RSASurrogate.ENCODED_SIZE)
         )
 
         checkedSerializeInlined(data, mask, PolySerializers)
@@ -45,7 +44,7 @@ class NestedClassesPolymorphicTest {
     @Test
     fun `different data objects of Polymorphic type within nested compound type should have same size after serialization`() {
         val data1 = Data(Some(generateRSAPubKey()))
-        val data2 = Data(Some(generateDSAPubKey()))
+        val data2 = Data(Some(generateRSAPubKey()))
 
         sameSizeInlined(data1, data2, PolySerializers)
         sameSize(data1, data2, PolySerializers)

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/NullablePolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/NullablePolymorphicTest.kt
@@ -1,0 +1,266 @@
+package com.ing.serialization.bfl.serde.serializers.custom.polymorphic
+
+import com.ing.serialization.bfl.annotations.FixedLength
+import com.ing.serialization.bfl.api.Surrogate
+import com.ing.serialization.bfl.api.SurrogateSerializer
+import com.ing.serialization.bfl.api.debugSerialize
+import com.ing.serialization.bfl.api.serialize
+import com.ing.serialization.bfl.serde.checkedSerializeInlined
+import com.ing.serialization.bfl.serde.element.ElementFactory
+import com.ing.serialization.bfl.serde.roundTrip
+import com.ing.serialization.bfl.serde.roundTripInlined
+import com.ing.serialization.bfl.serde.sameSize
+import com.ing.serialization.bfl.serde.sameSizeInlined
+import io.kotest.matchers.string.shouldMatch
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
+import kotlinx.serialization.modules.polymorphic
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+// =========================================== Polymorphic Base =========================================== //
+
+interface PolyBase
+data class VariantA(val myInt: Int) : PolyBase
+data class VariantB(val myLong: Long) : PolyBase
+data class VariantC(val myByte: Byte) : PolyBase
+
+object VariantASerializer : KSerializer<VariantA>
+by (SurrogateSerializer(VariantASurrogate.serializer()) { VariantASurrogate(it.myInt) })
+
+@Serializable
+data class VariantASurrogate(
+    @SerialName("myInt")
+    val value: Int
+) : Surrogate<VariantA> {
+    constructor(variantA: VariantA) : this(variantA.myInt)
+    override fun toOriginal() = VariantA(value)
+}
+
+object VariantBSerializer : KSerializer<VariantB>
+by (SurrogateSerializer(VariantBSurrogate.serializer()) { VariantBSurrogate(it.myLong) })
+
+@Serializable
+data class VariantBSurrogate(
+    @SerialName("myLong")
+    val value: Long
+) : Surrogate<VariantB> {
+    override fun toOriginal() = VariantB(value)
+}
+
+object VariantCSerializer : KSerializer<VariantC>
+by (SurrogateSerializer(VariantCSurrogate.serializer()) { VariantCSurrogate(it.myByte) })
+
+@Serializable
+data class VariantCSurrogate(
+    @SerialName("myByte")
+    val value: Byte
+) : Surrogate<VariantC> {
+    override fun toOriginal() = VariantC(value)
+}
+
+class NullablePolymorphicTest {
+    @Serializable
+    data class Data(@FixedLength([3]) val myList: List<PolyBase?>)
+
+    @Serializable
+    data class ComplexData(val myData: PolyBase?, @FixedLength([3]) val myList: List<PolyBase?>)
+
+    @Serializable
+    data class ComplexDataList(@FixedLength([3]) val dataList: List<ComplexData?>)
+
+    private val nullablePolySerializers = SerializersModule {
+        polymorphic(PolyBase::class) {
+            subclass(VariantA::class, VariantASerializer)
+            subclass(VariantB::class, VariantBSerializer)
+            subclass(VariantC::class, VariantCSerializer)
+        }
+        contextual(VariantASerializer)
+        contextual(VariantBSerializer)
+        contextual(VariantCSerializer)
+    }
+
+    @Test
+    fun `list with at least one non-null nullable polymorphic should be serialized successfully`() {
+        val data = Data(listOf(null, VariantA(0), null))
+
+        assertDoesNotThrow {
+            debugSerialize(data, serializersModule = nullablePolySerializers)
+        }.also {
+            println(it.second)
+        }
+    }
+
+    @Test
+    fun `list with at least one non-null nullable polymorphic should be the same after serialization and deserialization`() {
+        val data = Data(listOf(null, VariantA(0), null))
+
+        roundTripInlined(data, nullablePolySerializers)
+        roundTrip(data, nullablePolySerializers)
+    }
+
+    @Test
+    fun `different lists with at least one non-null nullable polymorphic should have same size after serialization`() {
+        val data1 = Data(listOf(null, VariantA(0), null))
+        val data2 = Data(listOf(VariantA(0), VariantA(1)))
+
+        sameSizeInlined(data1, data2, nullablePolySerializers)
+        sameSize(data1, data2, nullablePolySerializers)
+    }
+
+    @Test
+    fun `inner list with at least one non-null nullable polymorphic should be serialized successfully`() {
+        val data = ComplexData(VariantB(0), listOf(null, VariantA(0), null))
+
+        assertDoesNotThrow {
+            debugSerialize(data, serializersModule = nullablePolySerializers)
+        }.also {
+            println(it.second)
+        }
+    }
+
+    @Test
+    fun `inner list with at least one non-null nullable polymorphic should be the same after serialization and deserialization`() {
+        val data = ComplexData(VariantB(0), listOf(null, VariantA(0), null))
+
+        roundTripInlined(data, nullablePolySerializers)
+        roundTrip(data, nullablePolySerializers)
+    }
+
+    @Test
+    fun `different inner lists with at least one non-null nullable polymorphic should have same size after serialization`() {
+        val data1 = ComplexData(VariantB(0), listOf(null, VariantA(0), null))
+        val data2 = ComplexData(VariantB(0), listOf(VariantA(0), VariantA(1), VariantA(2)))
+
+        sameSizeInlined(data1, data2, nullablePolySerializers)
+        sameSize(data1, data2, nullablePolySerializers)
+    }
+
+    @Test
+    @Suppress("LongMethod")
+    fun `list of nested nullable polymorphic should be serialized successfully when implementation for each inner polymorphic is provided`() {
+        val mask = listOf(
+            Pair("dataList.length", 4),
+            Pair("dataList[0].isNull", 1),
+            Pair("dataList[0].myData.isNull", 1),
+            Pair("dataList[0].myData.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("dataList[0].myData.value.myLong", 8),
+            Pair("dataList[0].myList.length", 4),
+            Pair("dataList[0].myList[0].isNull", 1),
+            Pair("dataList[0].myList[0].serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("dataList[0].myList[0].value.myInt", 4),
+            Pair("dataList[0].myList[1].isNull", 1),
+            Pair("dataList[0].myList[1].serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("dataList[0].myList[1].value.myInt", 4),
+            Pair("dataList[0].myList[2].isNull", 1),
+            Pair("dataList[0].myList[2].serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("dataList[0].myList[2].value.myInt", 4),
+            Pair("dataList[1].isNull", 1),
+            Pair("dataList[1].myData.isNull", 1),
+            Pair("dataList[1].myData.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("dataList[1].myData.value.myLong", 8),
+            Pair("dataList[1].myList.length", 4),
+            Pair("dataList[1].myList[0].isNull", 1),
+            Pair("dataList[1].myList[0].serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("dataList[1].myList[0].value.myInt", 4),
+            Pair("dataList[1].myList[1].isNull", 1),
+            Pair("dataList[1].myList[1].serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("dataList[1].myList[1].value.myInt", 4),
+            Pair("dataList[1].myList[2].isNull", 1),
+            Pair("dataList[1].myList[2].serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("dataList[1].myList[2].value.myInt", 4),
+            Pair("dataList[2].isNull", 1),
+            Pair("dataList[2].myData.isNull", 1),
+            Pair("dataList[2].myData.serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("dataList[2].myData.value.myLong", 8),
+            Pair("dataList[2].myList.length", 4),
+            Pair("dataList[2].myList[0].isNull", 1),
+            Pair("dataList[2].myList[0].serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("dataList[2].myList[0].value.myInt", 4),
+            Pair("dataList[2].myList[1].isNull", 1),
+            Pair("dataList[2].myList[1].serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("dataList[2].myList[1].value.myInt", 4),
+            Pair("dataList[2].myList[2].isNull", 1),
+            Pair("dataList[2].myList[2].serialName", 2 + 2 * ElementFactory.polySerialNameLength),
+            Pair("dataList[2].myList[2].value.myInt", 4),
+        )
+
+        val data = ComplexDataList(
+            listOf(
+                ComplexData(null, listOf(null, null, null)),
+                ComplexData(VariantB(0), listOf(null, VariantA(0), null)),
+            )
+        )
+
+        checkedSerializeInlined(data, mask, nullablePolySerializers)
+
+        assertDoesNotThrow {
+            debugSerialize(data, serializersModule = nullablePolySerializers)
+        }.also {
+            println(it.second)
+        }
+    }
+
+    @Test
+    fun `list of nested nullable polymorphic should be the same after serialization and deserialization`() {
+        val data = ComplexDataList(
+            listOf(
+                ComplexData(null, listOf(null, null, null)),
+                ComplexData(VariantB(0), listOf(null, VariantA(0), null)),
+            )
+        )
+
+        roundTripInlined(data, nullablePolySerializers)
+        roundTrip(data, nullablePolySerializers)
+    }
+
+    @Test
+    fun `different lists of nested nullable polymorphic should have same size after serialization`() {
+        val data1 = ComplexDataList(
+            listOf(
+                ComplexData(null, listOf(null, null, null)),
+                ComplexData(VariantB(0), listOf(null, VariantA(0), null)),
+            )
+        )
+        val data2 = ComplexDataList(
+            listOf(
+                ComplexData(VariantB(1), listOf(null, null, VariantA(0))),
+                ComplexData(VariantB(0), listOf(VariantA(0), VariantA(1), null)),
+            )
+        )
+
+        sameSizeInlined(data1, data2, nullablePolySerializers)
+        sameSize(data1, data2, nullablePolySerializers)
+    }
+
+    @Test
+    fun `Serialization of nullable polymorphic at any nesting level should fail when implementation cannot be inferred`() {
+        listOf(
+            Data(listOf()),
+            ComplexData(null, listOf(VariantA(0))),
+            ComplexData(VariantA(0), listOf(null)),
+            ComplexDataList(
+                listOf(
+                    ComplexData(null, listOf(null, null, null)),
+                    ComplexData(null, listOf(null, VariantA(0), null)),
+                )
+            ),
+            ComplexDataList(
+                listOf(
+                    ComplexData(VariantA(0), listOf(null)),
+                    ComplexData(null, listOf(null)),
+                )
+            ),
+        ).forEach {
+            assertThrows<IllegalStateException> {
+                serialize(it, serializersModule = nullablePolySerializers)
+            }.also { exception ->
+                exception.message shouldMatch Regex("Implementation of '.+' cannot be inferred")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PolymorphicTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PolymorphicTest.kt
@@ -17,9 +17,9 @@ class PolymorphicTest {
         println(data.encoded.joinToString(separator = ","))
 
         val mask = listOf(
-            Pair("serialName", PublicKeyBaseSurrogate.SERIAL_NAME_LENGTH),
+            Pair("serialName", RSASurrogate.SERIAL_NAME_LENGTH),
             Pair("length", 4),
-            Pair("value", PublicKeyBaseSurrogate.ENCODED_SIZE)
+            Pair("value", RSASurrogate.ENCODED_SIZE)
         )
         checkedSerializeInlined(data, mask, PolySerializers)
     }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PublicKeyDifferentSerializersTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PublicKeyDifferentSerializersTest.kt
@@ -2,14 +2,13 @@ package com.ing.serialization.bfl.serde.serializers.custom.polymorphic
 
 import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.api.serialize
+import com.ing.serialization.bfl.serde.SerdeError
 import com.ing.serialization.bfl.serde.generateDSAPubKey
 import com.ing.serialization.bfl.serde.generateRSAPubKey
-import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
-import java.lang.IllegalStateException
 import java.security.PublicKey
 
 class PublicKeyDifferentSerializersTest {
@@ -24,10 +23,8 @@ class PublicKeyDifferentSerializersTest {
         }
 
         val differentKeys = listOf(generateRSAPubKey(), generateDSAPubKey())
-        assertThrows<IllegalStateException> {
+        assertThrows<SerdeError.DifferentPolymorphicImplementations> {
             serialize(ListPolymorphicTest.Data(differentKeys), serializersModule = PolySerializers)
-        }.also {
-            it.message shouldBe "Different implementations of the same base type are not allowed"
         }
     }
 
@@ -47,10 +44,8 @@ class PublicKeyDifferentSerializersTest {
             serialize(NestedData(listOf(inner1, inner2)), serializersModule = PolySerializers)
         }
 
-        assertThrows<IllegalStateException> {
+        assertThrows<SerdeError.DifferentPolymorphicImplementations> {
             serialize(NestedData(listOf(inner1, inner3)), serializersModule = PolySerializers)
-        }.also {
-            it.message shouldBe "Different implementations of the same base type are not allowed"
         }
     }
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PublicKeyDifferentSerializersTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PublicKeyDifferentSerializersTest.kt
@@ -1,12 +1,15 @@
 package com.ing.serialization.bfl.serde.serializers.custom.polymorphic
 
 import com.ing.serialization.bfl.annotations.FixedLength
+import com.ing.serialization.bfl.api.serialize
 import com.ing.serialization.bfl.serde.generateDSAPubKey
 import com.ing.serialization.bfl.serde.generateRSAPubKey
-import com.ing.serialization.bfl.serde.roundTrip
-import com.ing.serialization.bfl.serde.roundTripInlined
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.lang.IllegalStateException
 import java.security.PublicKey
 
 class PublicKeyDifferentSerializersTest {
@@ -14,10 +17,40 @@ class PublicKeyDifferentSerializersTest {
     data class Data(@FixedLength([2]) val list: List<PublicKey>)
 
     @Test
-    fun `serialize different variants of a polymorphic type`() {
-        val data = Data(listOf(generateRSAPubKey(), generateDSAPubKey()))
+    fun `different variants of a polymorphic type should not coexist in a collection`() {
+        val sameKeys = listOf(generateRSAPubKey(), generateRSAPubKey())
+        assertDoesNotThrow {
+            serialize(ListPolymorphicTest.Data(sameKeys), serializersModule = PolySerializers)
+        }
 
-        roundTrip(data, PolySerializers)
-        roundTripInlined(data, PolySerializers)
+        val differentKeys = listOf(generateRSAPubKey(), generateDSAPubKey())
+        assertThrows<IllegalStateException> {
+            serialize(ListPolymorphicTest.Data(differentKeys), serializersModule = PolySerializers)
+        }.also {
+            it.message shouldBe "Different implementations of the same base type are not allowed"
+        }
+    }
+
+    @Serializable
+    data class InnerData(@FixedLength([10]) val name: String, val key: PublicKey)
+
+    @Serializable
+    data class NestedData(@FixedLength([2]) val nested: List<InnerData>)
+
+    @Test
+    fun `different variants of a nested polymorphic type should not coexist in a collection`() {
+        val inner1 = InnerData("inner1", generateRSAPubKey())
+        val inner2 = InnerData("inner2", generateRSAPubKey())
+        val inner3 = InnerData("inner3", generateDSAPubKey())
+
+        assertDoesNotThrow {
+            serialize(NestedData(listOf(inner1, inner2)), serializersModule = PolySerializers)
+        }
+
+        assertThrows<IllegalStateException> {
+            serialize(NestedData(listOf(inner1, inner3)), serializersModule = PolySerializers)
+        }.also {
+            it.message shouldBe "Different implementations of the same base type are not allowed"
+        }
     }
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PublicKeySerializers.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PublicKeySerializers.kt
@@ -11,16 +11,6 @@ import sun.security.rsa.RSAPublicKeyImpl
 import java.security.KeyFactory
 import java.security.spec.X509EncodedKeySpec
 
-abstract class PublicKeyBaseSurrogate {
-    @FixedLength([ENCODED_SIZE])
-    abstract val encoded: ByteArray
-
-    companion object {
-        const val ENCODED_SIZE = 900
-        const val SERIAL_NAME_LENGTH = 2 + 2 * 3
-    }
-}
-
 object RSAPublicKeySerializer : KSerializer<RSAPublicKeyImpl>
 by (SurrogateSerializer(RSASurrogate.serializer()) { RSASurrogate(it.encoded) })
 
@@ -31,20 +21,32 @@ by (SurrogateSerializer(DSASurrogate.serializer()) { DSASurrogate(it.encoded) })
 @Serializable
 @SerialName("RSA")
 data class RSASurrogate(
+    @SerialName("encodedKey")
     @FixedLength([ENCODED_SIZE])
-    override val encoded: ByteArray
-) : Surrogate<RSAPublicKeyImpl>, PublicKeyBaseSurrogate() {
+    val encoded: ByteArray
+) : Surrogate<RSAPublicKeyImpl> {
     override fun toOriginal(): RSAPublicKeyImpl =
         KeyFactory.getInstance("RSA").generatePublic(X509EncodedKeySpec(encoded)) as RSAPublicKeyImpl
+
+    companion object {
+        const val ENCODED_SIZE = 900
+        const val SERIAL_NAME_LENGTH = 2 + 2 * 3
+    }
 }
 
 @Suppress("ArrayInDataClass")
 @Serializable
 @SerialName("DSA")
 data class DSASurrogate(
+    @SerialName("encodedKey")
     @FixedLength([ENCODED_SIZE])
-    override val encoded: ByteArray
-) : Surrogate<DSAPublicKeyImpl>, PublicKeyBaseSurrogate() {
+    val encoded: ByteArray
+) : Surrogate<DSAPublicKeyImpl> {
     override fun toOriginal(): DSAPublicKeyImpl =
         KeyFactory.getInstance("DSA").generatePublic(X509EncodedKeySpec(encoded)) as DSAPublicKeyImpl
+
+    companion object {
+        const val ENCODED_SIZE = 900
+        const val SERIAL_NAME_LENGTH = 2 + 2 * 3
+    }
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PublicKeySerializers.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PublicKeySerializers.kt
@@ -12,16 +12,15 @@ import java.security.KeyFactory
 import java.security.spec.X509EncodedKeySpec
 
 object RSAPublicKeySerializer : KSerializer<RSAPublicKeyImpl>
-by (SurrogateSerializer(RSASurrogate.serializer()) { RSASurrogate(it.encoded) })
+by (SurrogateSerializer(RSASurrogate.serializer()) { RSASurrogate.from(it) })
 
 object DSAPublicKeySerializer : KSerializer<DSAPublicKeyImpl>
-by (SurrogateSerializer(DSASurrogate.serializer()) { DSASurrogate(it.encoded) })
+by (SurrogateSerializer(DSASurrogate.serializer()) { DSASurrogate.from(it) })
 
 @Suppress("ArrayInDataClass")
 @Serializable
 @SerialName("RSA")
 data class RSASurrogate(
-    @SerialName("encodedKey")
     @FixedLength([ENCODED_SIZE])
     val encoded: ByteArray
 ) : Surrogate<RSAPublicKeyImpl> {
@@ -31,6 +30,7 @@ data class RSASurrogate(
     companion object {
         const val ENCODED_SIZE = 900
         const val SERIAL_NAME_LENGTH = 2 + 2 * 3
+        fun from(rsaPublicKeyImpl: RSAPublicKeyImpl): RSASurrogate = RSASurrogate(rsaPublicKeyImpl.encoded)
     }
 }
 
@@ -38,7 +38,6 @@ data class RSASurrogate(
 @Serializable
 @SerialName("DSA")
 data class DSASurrogate(
-    @SerialName("encodedKey")
     @FixedLength([ENCODED_SIZE])
     val encoded: ByteArray
 ) : Surrogate<DSAPublicKeyImpl> {
@@ -48,5 +47,6 @@ data class DSASurrogate(
     companion object {
         const val ENCODED_SIZE = 900
         const val SERIAL_NAME_LENGTH = 2 + 2 * 3
+        fun from(dsaPublicKeyImpl: DSAPublicKeyImpl): DSASurrogate = DSASurrogate(dsaPublicKeyImpl.encoded)
     }
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PublicKeySerializers.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/custom/polymorphic/PublicKeySerializers.kt
@@ -3,7 +3,6 @@ package com.ing.serialization.bfl.serde.serializers.custom.polymorphic
 import com.ing.serialization.bfl.annotations.FixedLength
 import com.ing.serialization.bfl.api.Surrogate
 import com.ing.serialization.bfl.api.SurrogateSerializer
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import sun.security.provider.DSAPublicKeyImpl
@@ -11,11 +10,11 @@ import sun.security.rsa.RSAPublicKeyImpl
 import java.security.KeyFactory
 import java.security.spec.X509EncodedKeySpec
 
-object RSAPublicKeySerializer : KSerializer<RSAPublicKeyImpl>
-by (SurrogateSerializer(RSASurrogate.serializer()) { RSASurrogate.from(it) })
+object RSAPublicKeySerializer :
+    SurrogateSerializer<RSAPublicKeyImpl, RSASurrogate>(RSASurrogate.serializer(), { RSASurrogate(it.encoded) })
 
-object DSAPublicKeySerializer : KSerializer<DSAPublicKeyImpl>
-by (SurrogateSerializer(DSASurrogate.serializer()) { DSASurrogate.from(it) })
+object DSAPublicKeySerializer :
+    SurrogateSerializer<DSAPublicKeyImpl, DSASurrogate>(DSASurrogate.serializer(), { DSASurrogate(it.encoded) })
 
 @Suppress("ArrayInDataClass")
 @Serializable
@@ -30,7 +29,6 @@ data class RSASurrogate(
     companion object {
         const val ENCODED_SIZE = 900
         const val SERIAL_NAME_LENGTH = 2 + 2 * 3
-        fun from(rsaPublicKeyImpl: RSAPublicKeyImpl): RSASurrogate = RSASurrogate(rsaPublicKeyImpl.encoded)
     }
 }
 
@@ -47,6 +45,5 @@ data class DSASurrogate(
     companion object {
         const val ENCODED_SIZE = 900
         const val SERIAL_NAME_LENGTH = 2 + 2 * 3
-        fun from(dsaPublicKeyImpl: DSAPublicKeyImpl): DSASurrogate = DSASurrogate(dsaPublicKeyImpl.encoded)
     }
 }

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/doc/ImplementationTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/doc/ImplementationTest.kt
@@ -7,7 +7,6 @@ import com.ing.serialization.bfl.api.reified.deserialize
 import com.ing.serialization.bfl.api.reified.serialize
 import com.ing.serialization.bfl.serde.SerdeError
 import io.kotest.assertions.throwables.shouldThrow
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.contextual
@@ -41,12 +40,8 @@ data class CustomDataSurrogate(
     override fun toOriginal(): CustomData = CustomData(value)
 }
 
-object CustomDataSerializer : KSerializer<CustomData>
-by (
-    SurrogateSerializer(CustomDataSurrogate.serializer()) {
-        CustomDataSurrogate(it.value)
-    }
-    )
+object CustomDataSerializer :
+    SurrogateSerializer<CustomData, CustomDataSurrogate>(CustomDataSurrogate.serializer(), { CustomDataSurrogate(it.value) })
 
 val customDataSerializationModule = SerializersModule {
     contextual(CustomDataSerializer)

--- a/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/doc/ThirdPartyGenericsTest.kt
+++ b/src/test/kotlin/com/ing/serialization/bfl/serde/serializers/doc/ThirdPartyGenericsTest.kt
@@ -6,7 +6,6 @@ import com.ing.serialization.bfl.api.SurrogateSerializer
 import com.ing.serialization.bfl.serde.SerdeError
 import io.kotest.assertions.throwables.shouldThrow
 import kotlinx.serialization.Contextual
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
 import java.util.Currency
@@ -51,11 +50,9 @@ class ThirdPartyGenericsTest {
         override fun toOriginal(): CustomData<String> = CustomData(value)
     }
 
-    private object CustomDataStringSerializer : KSerializer<CustomData<String>>
-    by (
-        SurrogateSerializer(CustomDataStringSurrogate.serializer()) {
-            CustomDataStringSurrogate(it.value)
-        }
+    private object CustomDataStringSerializer :
+        SurrogateSerializer<CustomData<String>, CustomDataStringSurrogate>(
+            CustomDataStringSurrogate.serializer(), { CustomDataStringSurrogate(it.value) }
         )
 
     @Serializable
@@ -65,9 +62,7 @@ class ThirdPartyGenericsTest {
         override fun toOriginal(): CustomData<Currency> = CustomData(value)
     }
 
-    private object CustomDataCurrencySerializer : KSerializer<CustomData<Currency>> by (
-        SurrogateSerializer(CustomDataCurrencySurrogate.serializer()) {
-            CustomDataCurrencySurrogate(it.value)
-        }
-        )
+    private object CustomDataCurrencySerializer : SurrogateSerializer<CustomData<Currency>, CustomDataCurrencySurrogate>(
+        CustomDataCurrencySurrogate.serializer(), { CustomDataCurrencySurrogate(it.value) }
+    )
 }


### PR DESCRIPTION
Main changes introduced:
- Allow **only one subtype of a polymorphic** at any nesting level within a structure or a collection
- Add support for **nullable polymorphic**
- Remove delegation from the instantiation of polymorphic serializers (**inherit directly from SurrogateSerializer** instead)