### PR TITLE
Remove check for mutable vars on objects

### DIFF
--- a/src/main/kotlin/com/ing/serialization/bfl/serde/SerdeError.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/SerdeError.kt
@@ -30,11 +30,6 @@ sealed class SerdeError : IllegalStateException {
                 "Please verify that all collections and strings in that chain are sufficiently annotated"
         )
 
-    class MutablePropertiesInObject(klass: KClass<*>) :
-        SerdeError(
-            "Mutable properties found in Object '$klass'. Stateful serialization is not supported for objects"
-        )
-
     class DifferentPolymorphicImplementations(serialName: String) :
         SerdeError("Different implementations of the same base type '$serialName' are not allowed")
 

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/Utils.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/Utils.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.modules.SerializersModule
 import kotlin.reflect.KClass
-import kotlin.reflect.KMutableProperty
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.isAccessible
 
@@ -83,16 +82,6 @@ fun <T> T.getPropertyNameValuePair(descriptor: SerialDescriptor, index: Int): Pa
             ?.call(it)
     }
     return Pair(propertyName, propertyValue)
-}
-
-/**
- * Extension function that retrieves an object and checks recursively whether it contains any mutable properties
- */
-fun <T : Any> T.hasMutableProperties(): Boolean {
-    val (mutable, immutable) = this::class.memberProperties.partition { it is KMutableProperty<*> }
-    return if (mutable.isEmpty()) {
-        immutable.filterNot { it.isConst }.any { it.call(this)?.hasMutableProperties() ?: false }
-    } else { true }
 }
 
 /**

--- a/src/main/kotlin/com/ing/serialization/bfl/serde/element/ElementFactory.kt
+++ b/src/main/kotlin/com/ing/serialization/bfl/serde/element/ElementFactory.kt
@@ -5,7 +5,6 @@ import com.ing.serialization.bfl.serde.SerdeError
 import com.ing.serialization.bfl.serde.expect
 import com.ing.serialization.bfl.serde.flattenToList
 import com.ing.serialization.bfl.serde.getPropertyNameValuePair
-import com.ing.serialization.bfl.serde.hasMutableProperties
 import com.ing.serialization.bfl.serde.isCollection
 import com.ing.serialization.bfl.serde.isContextual
 import com.ing.serialization.bfl.serde.isEnum
@@ -24,7 +23,6 @@ import kotlinx.serialization.descriptors.getContextualDescriptor
 import kotlinx.serialization.descriptors.getPolymorphicDescriptors
 import kotlinx.serialization.modules.EmptySerializersModule
 import kotlinx.serialization.modules.SerializersModule
-import kotlin.collections.ArrayDeque
 import kotlin.reflect.KClass
 
 class ElementFactory(
@@ -88,12 +86,7 @@ class ElementFactory(
                 StringElement(serialName, parentName, requiredLength, descriptor.isNullable)
             }
             descriptor.isEnum -> EnumElement(serialName, parentName, descriptor.isNullable)
-            descriptor.isObject -> {
-                data?.let {
-                    it.hasMutableProperties() && throw SerdeError.MutablePropertiesInObject(it::class)
-                }
-                StructureElement(serialName, parentName, mutableListOf(), descriptor.isNullable)
-            }
+            descriptor.isObject -> StructureElement(serialName, parentName, mutableListOf(), descriptor.isNullable)
             descriptor.isCollection -> fromCollection(descriptor, serialName, parentName, data)
             descriptor.isStructure -> fromStructure(descriptor, serialName, parentName, data)
             descriptor.isPolymorphic -> fromPolymorphic(descriptor, serialName, parentName, data)


### PR DESCRIPTION
The curren situation breaks things in unexpected ways. 

1) the `hasMutableProperties` function gives unexpected results for Ivno's `DepositContract.Request`. It tells me that some private fields of the java class SingletonMap are mutable, while on Kotlin level, the map is declared as:
```kotlin
val componentGroupSizes: Map<ComponentGroupEnum, Int> = mapOf(
        ComponentGroupEnum.SIGNERS_GROUP to 2
    )
```
This clearly not mutable.

2) The whole approach of failing on encountering mutable state is not how it should be.
We should mimic the behaviour of Corda here, which does the following:
`They are recorded into the stream with no properties, and deserialize
back to the singleton instance.`
https://docs.corda.net/docs/corda-os/4.8/serialization.html#kotlin-objects

This is not unreasonable. In other well-known serialization libs like Jackson,
The approach for this has been a long debate and the result is that
how mutable state of objects is handled is configurable. But in no
case do they fail serialization if mutable state is encountered.

We could possibly choose to emit a log warning here,
but it seems we have nog logging mechanism configured.